### PR TITLE
[Build] Github Actions를 이용한 CI 빌드, 테스트 자동화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SUBMODULE_TOKEN }}
+          submodules: recursive
+
+      - name: Set Up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/**/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,11 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: '**/build/test-results/**/*.xml'
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: If the test fails, register a check comment in the failed code line
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ### CUSTOM ###
-*.yml
+application*.yml
 
 HELP.md
 .gradle
@@ -38,3 +38,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Mac OS ###
+.DS_Store

--- a/Module-API/src/main/java/depromeet/HelloController.java
+++ b/Module-API/src/main/java/depromeet/HelloController.java
@@ -1,0 +1,15 @@
+package depromeet;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class HelloController {
+
+    @GetMapping("/")
+    @ResponseBody
+    public String home() {
+        return "hello world";
+    }
+}

--- a/Module-API/src/test/java/depromeet/HelloControllerTest.java
+++ b/Module-API/src/test/java/depromeet/HelloControllerTest.java
@@ -1,0 +1,31 @@
+package depromeet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {HelloController.class})
+@Import(HelloController.class)
+@DisplayName("[Controller] Health check")
+class HelloControllerTest {
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    @DisplayName("[GET] Health check test")
+    void testHealthCheckTest() throws Exception {
+        mvc.perform(get("/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string("hello world"));
+    }
+}


### PR DESCRIPTION
## 개요
- close #1 

## 작업사항
- [x] 빌드(build) 성공 체크
- [x] 테스트(unit test) 통과 체크

- 동호님이 저번에 말씀하신 테스트 커버리지 관련해서 Jacoco Report 많이 사용하던데 아직 테스트 코드가 많지 않았어 `EnricoMi/publish-unit-test-result-action@v2` 액션 사용했어요!
- 테스트 결과를 포매팅해서 PR 코멘트를 달아주는데 꽤 깔끔하더라고요! 나중에 필요해지면 Jacoco 추가해보겠습니다.
- 테스트 실패 시 Files changed에 들어가면 코멘트 확인이 되고, 해당 부분이 수정되면 코멘트는 자동 삭제되는 액션도 추가했어요.
- 그리고 Lint 검사하는 스탭은 추가하려다가 멈췄습니다.
- ci에서 작업이 많아지면 시간이 너무 오래 걸릴 거라고 판단했고, ci시 말고 커밋할 때 Lint 성공해야 하도록 설정하려고 한다. 
- node에서는 허스키라는 git hook 사용하더라고요! [자바 버전](https://github.com/Dathin/JHuskytest/TEST-*.xml')으로 만드신 분이 계시긴 하던데 더 찾아봐야 할 거 같아요 🧐

## Etc.
- 정윤 포스팅 : [Github Actions를 이용한 CI 빌드, 테스트 자동화](https://hello-judy-world.tistory.com/210)