### PR TITLE
[Refactor] reissue API에서 토큰을 보내는 방법 수정

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/auth/controller/AuthController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/auth/controller/AuthController.java
@@ -13,7 +13,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -23,7 +22,6 @@ public class AuthController {
     private final KakaoAuthUseCase kakaoAuthUseCase;
     private final AuthUseCase authUseCase;
     private final CookieUtil cookieUtil;
-    private static final String REFRESH_TOKEN = "refreshToken";
 
     @PostMapping("/auth/kakao")
     public CommonResponse auth(
@@ -35,13 +33,9 @@ public class AuthController {
     }
 
     @PostMapping("/auth/refresh")
-    public CommonResponse refreshToken(
-            @RequestHeader("AUTHORIZATION") String token,
-            HttpServletRequest httpServletRequest,
-            HttpServletResponse httpServletResponse) {
-        String refreshToken = cookieUtil.getCookie(httpServletRequest, REFRESH_TOKEN).getValue();
-        String accessToken = authUseCase.checkRefreshToken(token, refreshToken);
-        httpServletResponse.setHeader("AUTHORIZATION", accessToken);
-        return ResponseService.getSuccessResponse();
+    public CommonResponse refreshToken(HttpServletRequest request) {
+        String refreshToken = cookieUtil.getCookie(request, "RefreshToken").getValue();
+        String accessToken = authUseCase.checkRefreshToken(refreshToken);
+        return ResponseService.getDataResponse(KakaoAuthResponse.of(refreshToken, accessToken));
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/auth/usecase/AuthUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/auth/usecase/AuthUseCase.java
@@ -20,15 +20,15 @@ public class AuthUseCase {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
-    public String checkRefreshToken(String token, String refreshToken) {
-        String socialId = jwtUtil.getUsername(token);
+    public String checkRefreshToken(String refreshToken) {
+        String socialId = jwtUtil.getUsername(refreshToken);
         String refresh = redisTemplate.opsForValue().get(socialId);
 
         if (refresh == null) {
-            throw new CustomException(CustomExceptionStatus.INVALID_JWT);
+            throw new CustomException(CustomExceptionStatus.INVALID_REFRESH_TOKEN);
         }
         if (!refresh.equals(refreshToken)) {
-            throw new CustomException(CustomExceptionStatus.INVALID_JWT);
+            throw new CustomException(CustomExceptionStatus.INVALID_REFRESH_TOKEN);
         }
         User account = userAdaptor.findUser(socialId);
 

--- a/Module-API/src/test/java/depromeet/api/controller/AuthControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/controller/AuthControllerTest.java
@@ -48,22 +48,21 @@ public class AuthControllerTest {
     @Test
     @DisplayName("Refresh Token을 이용한 Access Token 재발급")
     public void refreshTokenTest() throws Exception {
-        String token = "access-token";
         String refreshToken = "refresh-token";
         String newAccessToken = "new-access-token";
         Cookie cookie = new Cookie("REFRESH_TOKEN", refreshToken);
 
         MockHttpServletRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.post("/auth/refresh")
-                        .header("AUTHORIZATION", token)
                         .header("REFRESH-TOKEN", refreshToken)
                         .contentType(MediaType.APPLICATION_JSON);
 
         when(cookieUtil.getCookie(any(), anyString())).thenReturn(cookie);
-        when(authUseCase.checkRefreshToken(anyString(), anyString())).thenReturn(newAccessToken);
+        when(authUseCase.checkRefreshToken(anyString())).thenReturn(newAccessToken);
 
         mockMvc.perform(requestBuilder)
                 .andDo(print())
-                .andExpectAll(status().isOk(), header().string("AUTHORIZATION", newAccessToken));
+                .andExpectAll(
+                        status().isOk(), jsonPath("$.result.accessToken").value(newAccessToken));
     }
 }


### PR DESCRIPTION
## 개요
- close #46 

## 작업사항
- reissue API, 테스트 코드 수정

## 변경로직
- Access Token은 body에 담아서 전송
- Header에서 Access Token을 받는 부분 제거(Access Token이 없거나 유효하지 않기 때문에 reissue API를 호출해서)