### PR TITLE
[Refactor] CreateChallengeRequest에서 challengeRule 필드의 타입 수정

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/dto/request/CreateChallengeRequest.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/dto/request/CreateChallengeRequest.java
@@ -1,7 +1,6 @@
 package depromeet.api.domain.challenge.dto.request;
 
 
-import depromeet.domain.rule.domain.ChallengeRule;
 import java.time.LocalDate;
 import java.util.List;
 import javax.validation.constraints.Max;
@@ -35,7 +34,7 @@ public class CreateChallengeRequest {
     @NotNull
     private Integer availableCount;
 
-    private List<ChallengeRule> challengeRule;
+    private List<String> challengeRule;
 
     @NotNull private Integer period;
 

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/CreateChallengeUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/CreateChallengeUseCase.java
@@ -4,6 +4,7 @@ package depromeet.api.domain.challenge.usecase;
 import depromeet.api.domain.challenge.dto.request.CreateChallengeRequest;
 import depromeet.api.domain.challenge.dto.response.CreateChallengeResponse;
 import depromeet.api.domain.challenge.mapper.ChallengeMapper;
+import depromeet.api.domain.rule.mapper.ChallengeRuleMapper;
 import depromeet.common.annotation.UseCase;
 import depromeet.domain.category.adaptor.CategoryAdaptor;
 import depromeet.domain.category.domain.Category;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateChallengeUseCase {
 
     private final ChallengeMapper challengeMapper;
+    private final ChallengeRuleMapper challengeRuleMapper;
     private final ChallengeAdaptor challengeAdaptor;
     private final CategoryAdaptor categoryAdaptor;
     private final UserAdaptor userAdaptor;
@@ -43,7 +45,7 @@ public class CreateChallengeUseCase {
         Challenge challenge = challengeMapper.toEntity(request, socialId);
 
         challenge.addCategories(categories);
-        challenge.addRules(request.getChallengeRule());
+        challenge.addRules(challengeRuleMapper.toEntities(request.getChallengeRule()));
         challenge.addKeywords(keywords);
 
         return challenge;

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/UpdateChallengeUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/UpdateChallengeUseCase.java
@@ -42,8 +42,7 @@ public class UpdateChallengeUseCase {
         List<Keyword> keywords = keywordAdaptor.findOrCreateKeywords(request.getKeywords());
         List<Category> categories =
                 categoryAdaptor.findOrExceptionCategories(request.getCategories());
-        List<ChallengeRule> challengeRules =
-                ChallengeRule.toEntities(request.getRules(), challenge);
+        List<ChallengeRule> challengeRules = ChallengeRule.createRule(request.getRules());
 
         challenge.updateTitle(request.getTitle());
         challenge.updatePrice(request.getPrice());

--- a/Module-API/src/main/java/depromeet/api/domain/rule/mapper/ChallengeRuleMapper.java
+++ b/Module-API/src/main/java/depromeet/api/domain/rule/mapper/ChallengeRuleMapper.java
@@ -2,15 +2,15 @@ package depromeet.api.domain.rule.mapper;
 
 
 import depromeet.common.annotation.Mapper;
-import depromeet.domain.challenge.domain.Challenge;
 import depromeet.domain.rule.domain.ChallengeRule;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @Mapper
 @RequiredArgsConstructor
 public class ChallengeRuleMapper {
 
-    public ChallengeRule toEntity(String content, Challenge challenge) {
-        return ChallengeRule.createRule(content, challenge);
+    public List<ChallengeRule> toEntities(List<String> content) {
+        return ChallengeRule.createRule(content);
     }
 }

--- a/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
@@ -81,6 +81,9 @@ public class ChallengeControllerTest {
         keywords.add("#마라탕");
         keywords.add("#5만원챌린지");
 
+        List<String> rules = new ArrayList<>();
+        rules.add("광고 금지");
+
         CreateChallengeRequest request =
                 CreateChallengeRequest.builder()
                         .category(categories)
@@ -89,7 +92,7 @@ public class ChallengeControllerTest {
                         .imageUrl("test.jpg")
                         .keywords(keywords)
                         .availableCount(30)
-                        // .challengeRule(rules) List<String>을 받도록 수정할 예정
+                        .challengeRule(rules)
                         .period(15)
                         .startAt(LocalDate.of(2023, 6, 1))
                         .endAt(LocalDate.of(2023, 6, 15))

--- a/Module-Domain/src/main/java/depromeet/domain/rule/domain/ChallengeRule.java
+++ b/Module-Domain/src/main/java/depromeet/domain/rule/domain/ChallengeRule.java
@@ -31,12 +31,8 @@ public class ChallengeRule {
         this.content = content;
     }
 
-    public static ChallengeRule createRule(String content, Challenge challenge) {
-        return ChallengeRule.builder().content(content).challenge(challenge).build();
-    }
-
-    public static List<ChallengeRule> toEntities(List<String> rules, Challenge challenge) {
-        return rules.stream().map(rule -> createRule(rule, challenge)).collect(Collectors.toList());
+    public static List<ChallengeRule> createRule(List<String> content) {
+        return content.stream().map(ChallengeRule::new).collect(Collectors.toList());
     }
 
     public void setChallenge(Challenge challenge) {


### PR DESCRIPTION
## 개요
- close #113 

## 작업사항
- 챌린지 생성 요청 DTO에서 challengeRule의 필드를 `List<String>`으로 변경
- 테스트 코드 수정

## 변경로직
- ChallengeRule의 createRule 메서드는 content 필드만 파라미터로 받는다.