### PR TITLE
[Feature] 마이페이지 조회 구현

### DIFF
--- a/Module-API/src/main/java/depromeet/api/config/security/SecurityConfig.java
+++ b/Module-API/src/main/java/depromeet/api/config/security/SecurityConfig.java
@@ -33,7 +33,6 @@ public class SecurityConfig {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/image/**").hasRole("USER")
-                .antMatchers("/record/**").hasRole("USER")
                 .antMatchers("/mypage/**").hasRole("USER")
                 .antMatchers("/challenge/**").hasAnyRole("USER", "GUEST")
                 .antMatchers("/auth/**", "/guest").permitAll()

--- a/Module-API/src/main/java/depromeet/api/config/security/SecurityConfig.java
+++ b/Module-API/src/main/java/depromeet/api/config/security/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/image/**").hasRole("USER")
+                .antMatchers("/record/**").hasRole("USER")
+                .antMatchers("/mypage/**").hasRole("USER")
                 .antMatchers("/challenge/**").hasAnyRole("USER", "GUEST")
                 .antMatchers("/auth/**", "/guest").permitAll()
 

--- a/Module-API/src/main/java/depromeet/api/domain/mypage/controller/MyPageController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/mypage/controller/MyPageController.java
@@ -3,6 +3,8 @@ package depromeet.api.domain.mypage.controller;
 import static depromeet.api.util.AuthenticationUtil.getCurrentUserSocialId;
 
 import depromeet.api.domain.mypage.dto.request.UpdateProfileRequest;
+import depromeet.api.domain.mypage.dto.response.GetMyPageResponse;
+import depromeet.api.domain.mypage.usecase.GetMyPageUseCase;
 import depromeet.api.domain.mypage.usecase.LogoutUseCase;
 import depromeet.api.domain.mypage.usecase.UpdateProfileUseCase;
 import depromeet.common.exception.CustomExceptionStatus;
@@ -19,8 +21,16 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/mypage")
 @RequiredArgsConstructor
 public class MyPageController {
+    private final GetMyPageUseCase getMyPageUseCase;
     private final UpdateProfileUseCase updateProfileUseCase;
     private final LogoutUseCase logoutUseCase;
+
+    @Operation(summary = "마이페이지 조회 API")
+    @GetMapping()
+    public Response<GetMyPageResponse> getUserProfile() {
+
+        return ResponseService.getDataResponse(getMyPageUseCase.execute(getCurrentUserSocialId()));
+    }
 
     @Operation(summary = "사용자 프로필을 수정하는 API")
     @PatchMapping("/profile")
@@ -34,6 +44,7 @@ public class MyPageController {
     @Operation(summary = "사용자 로그아웃 API")
     @PostMapping("/logout")
     public Response<CustomExceptionStatus> logout() {
+
         logoutUseCase.execute(getCurrentUserSocialId());
         return ResponseService.getDataResponse(CustomExceptionStatus.SUCCESS);
     }

--- a/Module-API/src/main/java/depromeet/api/domain/mypage/dto/response/GetMyPageResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/mypage/dto/response/GetMyPageResponse.java
@@ -1,0 +1,25 @@
+package depromeet.api.domain.mypage.dto.response;
+
+
+import depromeet.domain.user.domain.Profile;
+import depromeet.domain.userchallenge.domain.Status;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetMyPageResponse {
+    private Profile profile;
+    private Boolean notification;
+    private Map<Status, Integer> userChallengeResult;
+
+    public static GetMyPageResponse of(
+            Profile profile, Boolean notification, Map<Status, Integer> userChallengeResult) {
+        return GetMyPageResponse.builder()
+                .profile(profile)
+                .notification(notification)
+                .userChallengeResult(userChallengeResult)
+                .build();
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/mypage/mapper/MyPageMapper.java
+++ b/Module-API/src/main/java/depromeet/api/domain/mypage/mapper/MyPageMapper.java
@@ -1,0 +1,18 @@
+package depromeet.api.domain.mypage.mapper;
+
+
+import depromeet.api.domain.mypage.dto.response.GetMyPageResponse;
+import depromeet.common.annotation.Mapper;
+import depromeet.domain.user.domain.Profile;
+import depromeet.domain.userchallenge.domain.Status;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@Mapper
+@RequiredArgsConstructor
+public class MyPageMapper {
+    public GetMyPageResponse toGetMyPageResponse(
+            Profile profile, Boolean notification, Map<Status, Integer> userChallengeResult) {
+        return GetMyPageResponse.of(profile, notification, userChallengeResult);
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/mypage/usecase/GetMyPageUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/mypage/usecase/GetMyPageUseCase.java
@@ -1,0 +1,61 @@
+package depromeet.api.domain.mypage.usecase;
+
+
+import depromeet.api.domain.mypage.dto.response.GetMyPageResponse;
+import depromeet.api.domain.mypage.mapper.MyPageMapper;
+import depromeet.common.annotation.UseCase;
+import depromeet.domain.user.adaptor.UserAdaptor;
+import depromeet.domain.user.domain.Profile;
+import depromeet.domain.user.domain.User;
+import depromeet.domain.userchallenge.adaptor.UserChallengeAdaptor;
+import depromeet.domain.userchallenge.domain.Status;
+import depromeet.domain.userchallenge.domain.UserChallenge;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetMyPageUseCase {
+    private final MyPageMapper myPageMapper;
+    private final UserAdaptor userAdaptor;
+    private final UserChallengeAdaptor userChallengeAdaptor;
+
+    public GetMyPageResponse execute(String socialId) {
+        User user = userAdaptor.findUser(socialId);
+        Profile profile = user.getProfile();
+
+        Boolean notification = user.getNotification();
+
+        List<UserChallenge> challengeList =
+                userChallengeAdaptor.findUserChallengeList(user.getId());
+        Map<Status, Integer> userChallengeResult = checkUserChallengeStatusCount(challengeList);
+
+        return myPageMapper.toGetMyPageResponse(profile, notification, userChallengeResult);
+    }
+
+    private Map<Status, Integer> checkUserChallengeStatusCount(List<UserChallenge> challengeList) {
+        Map<Status, Integer> userChallengeResult = new HashMap<>();
+
+        int proceedingCount = countUserChallengeByStatus(challengeList, Status.PROCEEDING);
+        userChallengeResult.put(Status.PROCEEDING, proceedingCount);
+        int successCount = countUserChallengeByStatus(challengeList, Status.SUCCESS);
+        userChallengeResult.put(Status.SUCCESS, successCount);
+        // 완료는 성공 + 실패
+        int failureCount = countUserChallengeByStatus(challengeList, Status.FAILURE);
+        userChallengeResult.put(Status.COMPLETED, successCount + failureCount);
+
+        return userChallengeResult;
+    }
+
+    private int countUserChallengeByStatus(List<UserChallenge> challengeList, Status status) {
+        long count =
+                challengeList.stream()
+                        .filter(userChallenge -> userChallenge.getStatus() == status)
+                        .count();
+        return (int) count;
+    }
+}

--- a/Module-API/src/test/java/depromeet/api/domain/mypage/controller/MyPageControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/mypage/controller/MyPageControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import depromeet.api.config.security.filter.JwtRequestFilter;
 import depromeet.api.domain.mypage.dto.request.UpdateProfileRequest;
+import depromeet.api.domain.mypage.usecase.GetMyPageUseCase;
 import depromeet.api.domain.mypage.usecase.LogoutUseCase;
 import depromeet.api.domain.mypage.usecase.UpdateProfileUseCase;
 import depromeet.api.util.AuthenticationUtil;
@@ -41,6 +42,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc(addFilters = false)
 class MyPageControllerTest {
     @Autowired private MockMvc mockMvc;
+    @MockBean private GetMyPageUseCase getMyPageUseCase;
     @MockBean private UpdateProfileUseCase updateProfileUseCase;
     @MockBean private LogoutUseCase logoutUseCase;
 
@@ -68,6 +70,7 @@ class MyPageControllerTest {
         MockHttpServletRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.patch("/mypage/profile", 1)
                         .with(csrf())
+                        .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(updateProfileRequest))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON);

--- a/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
@@ -144,6 +144,7 @@ class RecordControllerTest {
         MockHttpServletRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.post("/challenge/{challengeRoomId}/create", 1)
                         .with(csrf())
+                        .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(createRecordRequest))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON);
@@ -187,6 +188,7 @@ class RecordControllerTest {
         MockHttpServletRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.patch("/challenge/{recordId}", 1)
                         .with(csrf())
+                        .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(updateRecordRequest))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON);
@@ -215,6 +217,7 @@ class RecordControllerTest {
         MockHttpServletRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.delete("/challenge/{recordId}", 1)
                         .with(csrf())
+                        .characterEncoding("UTF-8")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON);
 

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.util.List;
 import javax.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Builder
 @Getter
@@ -39,6 +40,8 @@ public class Challenge extends BaseTime {
 
     private String imgUrl;
 
+    @Builder.Default
+    @ColumnDefault("false")
     private Boolean active = false;
 
     @Embedded private ChallengeKeywords challengeKeywords;

--- a/Module-Domain/src/main/java/depromeet/domain/user/domain/User.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/domain/User.java
@@ -7,9 +7,7 @@ import java.util.List;
 import javax.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
 
-@DynamicInsert
 @Builder
 @Getter
 @AllArgsConstructor

--- a/Module-Domain/src/main/java/depromeet/domain/user/domain/User.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/domain/User.java
@@ -6,7 +6,10 @@ import depromeet.domain.userchallenge.domain.UserChallenge;
 import java.util.List;
 import javax.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
+@DynamicInsert
 @Builder
 @Getter
 @AllArgsConstructor
@@ -18,6 +21,10 @@ public class User extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
+
+    @Builder.Default
+    @ColumnDefault("false")
+    private Boolean notification = false;
 
     @Embedded private Profile profile;
 

--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/Status.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/Status.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public enum Status {
     PROCEEDING("참가중"),
     SUCCESS("성공"),
-    FAILUR가E("실패"),
+    FAILURE("실패"),
     COMPLETED("완료");
 
     private final String value;

--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/Status.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/Status.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 public enum Status {
     PROCEEDING("참가중"),
     SUCCESS("성공"),
-    FAILURE("실패");
+    FAILUR가E("실패"),
+    COMPLETED("완료");
 
     private final String value;
 


### PR DESCRIPTION
## 개요
- close #133 

## 작업사항
- User에 Profile 정보

- 알림 설정 칼럼 추가 (default 값으로 false)
![image](https://github.com/depromeet/jalingobi-server/assets/97580782/378d7512-9a90-456d-996f-aadfa5232474)

- 유저가 참여중인 챌린지 분류해서 전달 (참가중, 성공, 완료)

## 변경로직
- 유저 알림 설정 여부, 챌린지 활성화 여부 default 값 설정
- test code에서 request utf-8 인코딩 코드 추가