### PR TITLE
[Refactor] user_challenge와 challenge_record 연관관계 추가

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/record/mapper/RecordMapper.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/mapper/RecordMapper.java
@@ -8,6 +8,7 @@ import depromeet.domain.challenge.domain.Challenge;
 import depromeet.domain.record.domain.Evaluation;
 import depromeet.domain.record.domain.Record;
 import depromeet.domain.user.domain.User;
+import depromeet.domain.userchallenge.domain.UserChallenge;
 import lombok.RequiredArgsConstructor;
 
 @Mapper
@@ -15,10 +16,14 @@ import lombok.RequiredArgsConstructor;
 public class RecordMapper {
 
     public Record toEntity(
-            Challenge challenge, User user, CreateRecordRequest createRecordRequest) {
+            Challenge challenge,
+            User user,
+            UserChallenge userChallenge,
+            CreateRecordRequest createRecordRequest) {
         return Record.createRecord(
                 challenge,
                 user,
+                userChallenge,
                 createRecordRequest.getPrice(),
                 createRecordRequest.getTitle(),
                 createRecordRequest.getContent(),

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
@@ -12,6 +12,8 @@ import depromeet.domain.record.adaptor.RecordAdaptor;
 import depromeet.domain.record.domain.Record;
 import depromeet.domain.user.adaptor.UserAdaptor;
 import depromeet.domain.user.domain.User;
+import depromeet.domain.userchallenge.adaptor.UserChallengeAdaptor;
+import depromeet.domain.userchallenge.domain.UserChallenge;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +25,7 @@ public class CreateRecordUseCase {
     private final RecordAdaptor recordAdaptor;
     private final UserAdaptor userAdaptor;
     private final ChallengeAdaptor challengeAdaptor;
+    private final UserChallengeAdaptor userChallengeAdaptor;
 
     private final RecordValidator recordValidator;
 
@@ -31,12 +34,15 @@ public class CreateRecordUseCase {
 
         User currentUser = userAdaptor.findUser(socialId);
         Challenge challenge = challengeAdaptor.findChallenge(challengeRoomId);
+        UserChallenge userChallenge =
+                userChallengeAdaptor.findByUserChallenge(challenge, currentUser);
 
         recordValidator.validateUnparticipatedChallenge(socialId, challenge);
 
         Record record =
                 recordAdaptor.save(
-                        recordMapper.toEntity(challenge, currentUser, createRecordRequest));
+                        recordMapper.toEntity(
+                                challenge, currentUser, userChallenge, createRecordRequest));
 
         return recordMapper.toCreateRecordResponse(record, currentUser);
     }

--- a/Module-Domain/src/main/java/depromeet/domain/record/domain/Record.java
+++ b/Module-Domain/src/main/java/depromeet/domain/record/domain/Record.java
@@ -31,6 +31,10 @@ public class Record extends BaseTime {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_challenge_id)")
+    private UserChallenge userChallenge;
+
     @Embedded private Comments comments;
 
     @Embedded private Emojis emojis;
@@ -54,6 +58,7 @@ public class Record extends BaseTime {
     public static Record createRecord(
             Challenge challenge,
             User user,
+            UserChallenge userChallenge,
             int price,
             String title,
             String content,
@@ -62,6 +67,7 @@ public class Record extends BaseTime {
         return Record.builder()
                 .challenge(challenge)
                 .user(user)
+                .userChallenge(userChallenge)
                 .price(price)
                 .title(title)
                 .content(content)

--- a/Module-Domain/src/test/java/depromeet/domain/record/adaptor/RecordAdaptorTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/record/adaptor/RecordAdaptorTest.java
@@ -17,6 +17,8 @@ import depromeet.domain.user.domain.Platform;
 import depromeet.domain.user.domain.Profile;
 import depromeet.domain.user.domain.Social;
 import depromeet.domain.user.domain.User;
+import depromeet.domain.userchallenge.domain.Status;
+import depromeet.domain.userchallenge.domain.UserChallenge;
 import java.time.LocalDate;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,8 +74,18 @@ class RecordAdaptorTest {
                                         .build())
                         .build();
 
+        UserChallenge userChallenge =
+                UserChallenge.builder()
+                        .user(user)
+                        .challenge(challenge)
+                        .nickname("ae정윤")
+                        .currentCharge(500)
+                        .status(Status.PROCEEDING)
+                        .build();
+
         Record record =
-                Record.createRecord(challenge, user, 4000, "커피", "커피는 무죄", "", Evaluation.ONE);
+                Record.createRecord(
+                        challenge, user, userChallenge, 4000, "커피", "커피는 무죄", "", Evaluation.ONE);
 
         given(recordRepository.save(record)).willReturn(record);
 


### PR DESCRIPTION
## 개요
- close #142 

## 작업사항
- 피드 조회 요구사항으로 user_challenge와 challenge_record 1:n으로 연관관계 추가
- 챌린지 기록 시 user_id 와 challenge_id로 user_challenge 조회해서 값 추가

## 변경로직
- 연관관계 추가에 따른 챌린지 생성 로직 변경