### PR TITLE
[Refactor] 챌린지 기록 endpoint 수정 및 유저 Profile name 칼럼 명 변경

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/record/controller/RecordController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/controller/RecordController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "챌린지 기록", description = "챌린지 기록 API")
 @RestController
-@RequestMapping("/challenge")
+@RequestMapping("/record")
 @RequiredArgsConstructor
 public class RecordController {
     private final CreateRecordUseCase createRecordUseCase;

--- a/Module-API/src/test/java/depromeet/api/domain/mypage/controller/MyPageControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/mypage/controller/MyPageControllerTest.java
@@ -107,8 +107,8 @@ class MyPageControllerTest {
                 .andExpectAll(
                         status().isOk(),
                         jsonPath("$.result.social.id").value(getMyPageResponse.getSocial().getId()),
-                        jsonPath("$.result.profile.name")
-                                .value(getMyPageResponse.getProfile().getName()),
+                        jsonPath("$.result.profile.nickname")
+                                .value(getMyPageResponse.getProfile().getNickname()),
                         jsonPath("$.result.profile.email")
                                 .value(getMyPageResponse.getProfile().getEmail()),
                         jsonPath("$.result.profile.imgUrl")

--- a/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
@@ -98,7 +98,7 @@ class RecordControllerTest {
                         .build();
 
         MockHttpServletRequestBuilder requestBuilder =
-                MockMvcRequestBuilders.post("/challenge/{challengeId}/create", 1)
+                MockMvcRequestBuilders.post("/record/{challengeId}/create", 1)
                         .with(csrf())
                         .content(objectMapper.writeValueAsString(createRecordRequest))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -136,7 +136,7 @@ class RecordControllerTest {
                         .build();
 
         MockHttpServletRequestBuilder requestBuilder =
-                MockMvcRequestBuilders.post("/challenge/{challengeId}/create", 1)
+                MockMvcRequestBuilders.post("/record/{challengeId}/create", 1)
                         .with(csrf())
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(createRecordRequest))
@@ -180,7 +180,7 @@ class RecordControllerTest {
                         .build();
 
         MockHttpServletRequestBuilder requestBuilder =
-                MockMvcRequestBuilders.patch("/challenge/{recordId}", 1)
+                MockMvcRequestBuilders.patch("/record/{recordId}", 1)
                         .with(csrf())
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(updateRecordRequest))
@@ -209,7 +209,7 @@ class RecordControllerTest {
                         .build();
 
         MockHttpServletRequestBuilder requestBuilder =
-                MockMvcRequestBuilders.delete("/challenge/{recordId}", 1)
+                MockMvcRequestBuilders.delete("/record/{recordId}", 1)
                         .with(csrf())
                         .characterEncoding("UTF-8")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/Module-Domain/src/main/java/depromeet/domain/user/domain/Profile.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/domain/Profile.java
@@ -13,7 +13,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
     @Column(length = 20, nullable = false)
-    private String name;
+    private String nickname;
 
     @Column(length = 320, unique = true, nullable = false)
     private String email;
@@ -23,11 +23,11 @@ public class Profile {
 
     public static Profile createProfile(String name, String email) {
         String imgUrl = ImageUrlUtil.defaultImgUrl;
-        return Profile.builder().name(name).email(email).imgUrl(imgUrl).build();
+        return Profile.builder().nickname(name).email(email).imgUrl(imgUrl).build();
     }
 
     public void updateProfile(String nickname, String profileImgUrl) {
-        this.name = nickname;
+        this.nickname = nickname;
         this.imgUrl = profileImgUrl;
     }
 }

--- a/Module-Domain/src/test/java/depromeet/domain/user/domain/UserTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/user/domain/UserTest.java
@@ -22,7 +22,7 @@ class UserTest {
         User registerUser = User.registerUser(nickname, email, socialId, platform);
 
         // then
-        assertThat(registerUser.getProfile().getName()).isEqualTo(nickname);
+        assertThat(registerUser.getProfile().getNickname()).isEqualTo(nickname);
         assertThat(registerUser.getProfile().getEmail()).isEqualTo(email);
         assertThat(registerUser.getSocial().getId()).isEqualTo(socialId);
         assertThat(registerUser.getSocial().getPlatform()).isEqualTo(platform);


### PR DESCRIPTION
## 개요
- close #171 

## 작업사항 (=변경로직)
- 챌린지 기록 endpoint 수정
record로 기능을 명확하게

- 유저 이름을 dto에서는 nickname으로 받고 있는데, db 칼럼 명은 name. 파라미터 값 응답 값 같은 값에 대한 변수 명이 다름. 이를 통일