### PR TITLE
[Feature] 자린고비 홈 조회 구현

### DIFF
--- a/Module-API/src/main/java/depromeet/api/config/security/SecurityConfig.java
+++ b/Module-API/src/main/java/depromeet/api/config/security/SecurityConfig.java
@@ -34,6 +34,8 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/image/**").hasRole("USER")
                 .antMatchers("/mypage/**").hasRole("USER")
+                .antMatchers("/jalingobi/**").hasRole("USER")
+                .antMatchers("/record/**").hasRole("USER")
                 .antMatchers("/challenge/**").hasAnyRole("USER", "GUEST")
                 .antMatchers("/auth/**", "/guest").permitAll()
 

--- a/Module-API/src/main/java/depromeet/api/domain/jalingobi/controller/JalingobiController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/jalingobi/controller/JalingobiController.java
@@ -1,0 +1,30 @@
+package depromeet.api.domain.jalingobi.controller;
+
+import static depromeet.api.util.AuthenticationUtil.getCurrentUserSocialId;
+
+import depromeet.api.domain.jalingobi.dto.response.GetJalingobiResponse;
+import depromeet.api.domain.jalingobi.usecase.GetJalingobiUseCase;
+import depromeet.common.response.Response;
+import depromeet.common.response.ResponseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "자린고비", description = "자린고비 API")
+@RestController
+@RequestMapping("/jalingobi")
+@RequiredArgsConstructor
+public class JalingobiController {
+    private final GetJalingobiUseCase getJalingobiUseCase;
+
+    @Operation(summary = "자린고비 홈 조회 API")
+    @GetMapping()
+    public Response<GetJalingobiResponse> getJalingobiHome() {
+
+        return ResponseService.getDataResponse(
+                getJalingobiUseCase.execute(getCurrentUserSocialId()));
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/jalingobi/dto/response/GetJalingobiResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/jalingobi/dto/response/GetJalingobiResponse.java
@@ -1,0 +1,26 @@
+package depromeet.api.domain.jalingobi.dto.response;
+
+
+import depromeet.domain.jalingobi.domain.Jalingobi;
+import depromeet.domain.jalingobi.domain.Level;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetJalingobiResponse {
+    @Schema(description = "전체 자린고비 정보 리스트")
+    private List<Jalingobi> jalingobiList;
+
+    @Schema(description = "현재 사용자 자린고비 레벨")
+    private Level userLevel;
+
+    public static GetJalingobiResponse of(List<Jalingobi> jalingobiList, Level userLevel) {
+        return GetJalingobiResponse.builder()
+                .jalingobiList(jalingobiList)
+                .userLevel(userLevel)
+                .build();
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/jalingobi/mapper/JalingobiMapper.java
+++ b/Module-API/src/main/java/depromeet/api/domain/jalingobi/mapper/JalingobiMapper.java
@@ -1,0 +1,18 @@
+package depromeet.api.domain.jalingobi.mapper;
+
+
+import depromeet.api.domain.jalingobi.dto.response.GetJalingobiResponse;
+import depromeet.common.annotation.Mapper;
+import depromeet.domain.jalingobi.domain.Jalingobi;
+import depromeet.domain.jalingobi.domain.Level;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@Mapper
+@RequiredArgsConstructor
+public class JalingobiMapper {
+    public GetJalingobiResponse toGetJalingobiResponse(
+            List<Jalingobi> jalingobiList, Level userLevel) {
+        return GetJalingobiResponse.of(jalingobiList, userLevel);
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/jalingobi/usecase/GetJalingobiUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/jalingobi/usecase/GetJalingobiUseCase.java
@@ -1,0 +1,31 @@
+package depromeet.api.domain.jalingobi.usecase;
+
+
+import depromeet.api.domain.jalingobi.dto.response.GetJalingobiResponse;
+import depromeet.api.domain.jalingobi.mapper.JalingobiMapper;
+import depromeet.common.annotation.UseCase;
+import depromeet.domain.jalingobi.adaptor.JalingobiAdaptor;
+import depromeet.domain.jalingobi.domain.Jalingobi;
+import depromeet.domain.jalingobi.domain.Level;
+import depromeet.domain.user.adaptor.UserAdaptor;
+import depromeet.domain.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetJalingobiUseCase {
+    private final JalingobiMapper jalingobiMapper;
+    private final UserAdaptor userAdaptor;
+    private final JalingobiAdaptor jalingobiAdaptor;
+
+    public GetJalingobiResponse execute(String socialId) {
+        User user = userAdaptor.findUser(socialId);
+        Level userLevel = Level.getEnumTypeByScore(user.getScore());
+        List<Jalingobi> jalingobiList = jalingobiAdaptor.findAll();
+
+        return jalingobiMapper.toGetJalingobiResponse(jalingobiList, userLevel);
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/jalingobi/adaptor/JalingobiAdaptor.java
+++ b/Module-Domain/src/main/java/depromeet/domain/jalingobi/adaptor/JalingobiAdaptor.java
@@ -6,12 +6,21 @@ import depromeet.domain.jalingobi.domain.Jalingobi;
 import depromeet.domain.jalingobi.domain.Level;
 import depromeet.domain.jalingobi.exception.JalingobiNotFoundException;
 import depromeet.domain.jalingobi.repository.JalingobiRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @Adaptor
 @RequiredArgsConstructor
 public class JalingobiAdaptor {
     private final JalingobiRepository jalingobiRepository;
+
+    public List<Jalingobi> findAll() {
+        List<Jalingobi> jalingobiList = jalingobiRepository.findAll();
+        if (jalingobiList.isEmpty()) {
+            throw JalingobiNotFoundException.EXCEPTION;
+        }
+        return jalingobiList;
+    }
 
     public Jalingobi findJalingobi(Level level) {
         return jalingobiRepository

--- a/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Jalingobi.java
+++ b/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Jalingobi.java
@@ -32,10 +32,6 @@ public class Jalingobi {
     @Column(nullable = false)
     private String acquisitionCondition;
 
-    @OneToMany(
-            mappedBy = "jalingobi",
-            fetch = FetchType.LAZY,
-            cascade = CascadeType.PERSIST,
-            orphanRemoval = true)
+    @OneToMany(mappedBy = "jalingobi", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<SmallTalk> smallTalks = new ArrayList<>();
 }

--- a/Module-Domain/src/main/java/depromeet/domain/user/domain/User.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/domain/User.java
@@ -33,7 +33,7 @@ public class User extends BaseTime {
     private Boolean notification = false;
 
     @Column(nullable = false)
-    private int score;
+    private Integer score;
 
     @OneToMany(mappedBy = "user")
     private List<UserChallenge> userChallenges;


### PR DESCRIPTION
## 개요
- close #181 

## 작업사항
- 자린고비 조회
- 필요한거: 현재 유저의 자린고비 레벨, 모든 자린고비 레벨 정보

프론트에 더 필요한 정보 없는지 검토중입니다. 검토 끝나면 머지해야징٩( ᐛ )و

```json
{
  "isSuccess": true,
  "code": 0,
  "message": "string",
  "result": {
    "jalingobiList": [
      {
        "id": 0,
        "level": "LEVEL_0",
        "name": "string",
        "imgUrl": "string",
        "acquisitionCondition": "string",
        "smallTalks": [
          {
            "id": 0,
            "jalingobi": "string",
            "content": "string"
          }
        ]
      }
    ],
    "userLevel": "LEVEL_0"
  }
}
```

## 변경로직
- 코드리뷰 반영