### PR TITLE
[Feature] 챌린지 가입 시 유저 프로필 이미지도 저장

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/controller/ChallengeController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/controller/ChallengeController.java
@@ -35,7 +35,7 @@ public class ChallengeController {
     private final CreateChallengeUseCase challengeUseCase;
     private final UpdateChallengeUseCase updateChallengeUseCase;
     private final DeleteChallengeUseCase deleteChallengeUseCase;
-    private final JoinChallengeUseCase createUserChallengeUseCase;
+    private final JoinChallengeUseCase joinUserChallengeUseCase;
     private final GetChallengeUseCase getChallengeUseCase;
 
     @Operation(summary = "챌린지 생성 API", description = "챌린지를 생성합니다.")
@@ -89,7 +89,7 @@ public class ChallengeController {
     public CommonResponse joinChallenge(
             @PathVariable Long challengeId,
             @RequestBody @Valid JoinChallengeRequest createUserChallengeRequest) {
-        createUserChallengeUseCase.execute(
+        joinUserChallengeUseCase.execute(
                 getCurrentUserSocialId(), createUserChallengeRequest, challengeId);
         return ResponseService.getSuccessResponse();
     }

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/dto/request/JoinChallengeRequest.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/dto/request/JoinChallengeRequest.java
@@ -1,6 +1,7 @@
 package depromeet.api.domain.challenge.dto.request;
 
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,9 +14,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class JoinChallengeRequest {
 
-    @NotNull(message = "챌린지 동안 사용할 닉네임 입력하세요.")
+    @NotBlank(message = "챌린지 동안 사용할 닉네임 입력하세요.")
     private String nickname;
 
     @NotNull(message = "참여하는 챌린지의 목표 금액을 입력하세요.")
     private Integer currentCharge;
+
+    @NotBlank(message = "프로필 이미지 경로를 입력하세요.")
+    private String imgUrl;
 }

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/JoinChallengeUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/JoinChallengeUseCase.java
@@ -34,6 +34,7 @@ public class JoinChallengeUseCase {
                 UserChallenge.createUserChallenge(
                         user,
                         challenge,
+                        joinChallengeRequest.getImgUrl(),
                         joinChallengeRequest.getNickname(),
                         joinChallengeRequest.getCurrentCharge()));
     }

--- a/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
@@ -196,7 +196,11 @@ public class ChallengeControllerTest {
     public void joinChallengeTest() throws Exception {
         String socialId = "socialId";
         JoinChallengeRequest createUserChallengeRequest =
-                JoinChallengeRequest.builder().nickname("닉네임").currentCharge(10000).build();
+                JoinChallengeRequest.builder()
+                        .nickname("닉네임")
+                        .currentCharge(10000)
+                        .imgUrl("/test.jpg")
+                        .build();
 
         when(AuthenticationUtil.getCurrentUserSocialId()).thenReturn(socialId);
         willDoNothing().given(createUserChallengeUseCase).execute(anyString(), any(), anyLong());

--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
@@ -53,10 +53,11 @@ public class UserChallenge extends BaseTime {
     private List<Record> records = new ArrayList<>();
 
     public static UserChallenge createUserChallenge(
-            User user, Challenge challenge, String nickname, int currentCharge) {
+            User user, Challenge challenge, String imgUrl, String nickname, int currentCharge) {
         return UserChallenge.builder()
                 .user(user)
                 .challenge(challenge)
+                .imgUrl(imgUrl)
                 .nickname(nickname)
                 .currentCharge(currentCharge)
                 .status(Status.PROCEEDING)


### PR DESCRIPTION
## 개요
- close #202 

## 작업사항
- DTO에 이미지 필드 추가
- 컨트롤러 테스트 코드 수정

## 변경로직
- DTO에서 String은 NotBlank 어노테이션 사용
- 수정된 챌린지 가입 UseCase명으로 해당 변수명도 변경( createUserChallengeUseCase ➡️ joinUserChallengeUseCase)