### PR TITLE
[Feature] 참여중인 챌린지에서 내 방 정보 추가

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/feed/dto/response/GetMyChallengeListResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/feed/dto/response/GetMyChallengeListResponse.java
@@ -26,6 +26,10 @@ public class GetMyChallengeListResponse {
                         .map(ParticipatedChallenge::createParticipatedChallenge)
                         .collect(Collectors.toList());
 
+        // 맨 앞에 내 방 정보 추가
+        ParticipatedChallenge myRoom = new ParticipatedChallenge(0L, "내 방", "baseImg", true);
+        participatedChallengeList.add(0, myRoom);
+
         return new GetMyChallengeListResponse(participatedChallengeList);
     }
 }


### PR DESCRIPTION
## 개요
- close #201 

## 작업사항
- 참여중인 챌린지 리스트 맨 앞에 내 방 정보 추가
- imgUrl 값의 경우 현재는 "baseImg" 라는 임시값 들어가 있음