### PR TITLE
[Feature] 챌린지의 상태를 알 수 있는 로직 구현

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/GetChallengeResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/GetChallengeResponse.java
@@ -2,6 +2,7 @@ package depromeet.api.domain.challenge.dto.response;
 
 
 import depromeet.domain.challenge.domain.Challenge;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +29,8 @@ public class GetChallengeResponse {
 
     private List<String> rules;
 
+    private String status;
+
     private boolean isRecruiting;
 
     private DateInfoResponse dateInfo;
@@ -48,6 +51,7 @@ public class GetChallengeResponse {
                                 challenge.getUserChallenges().size()))
                 .rules(challenge.getChallengeRuleContents())
                 .isRecruiting(challenge.isRecruiting(challenge.getDuration().getStartAt()))
+                .status(challenge.checkStatus(LocalDate.from(challenge.getCreatedAt())))
                 .dateInfo(dateInfoResponse.toDateInfoResponse(challenge.getDuration()))
                 .participantsInfo(profileResponse.toProfileResponses(challenge.getUserChallenges()))
                 .build();

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/GetChallengeResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/GetChallengeResponse.java
@@ -51,7 +51,9 @@ public class GetChallengeResponse {
                                 challenge.getUserChallenges().size()))
                 .rules(challenge.getChallengeRuleContents())
                 .isRecruiting(challenge.isRecruiting(challenge.getDuration().getStartAt()))
-                .status(challenge.checkStatus(LocalDate.from(challenge.getCreatedAt())))
+                .status(
+                        challenge.checkStatusInChallengeDetail(
+                                LocalDate.from(challenge.getCreatedAt())))
                 .dateInfo(dateInfoResponse.toDateInfoResponse(challenge.getDuration()))
                 .participantsInfo(profileResponse.toProfileResponses(challenge.getUserChallenges()))
                 .build();

--- a/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
@@ -16,6 +16,7 @@ import depromeet.api.domain.challenge.dto.response.*;
 import depromeet.api.domain.challenge.mapper.ChallengeMapper;
 import depromeet.api.domain.challenge.usecase.*;
 import depromeet.api.util.AuthenticationUtil;
+import depromeet.domain.challenge.domain.StatusType;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -248,6 +249,7 @@ public class ChallengeControllerTest {
                         .participantsInfo(profileResponses)
                         .rules(rules)
                         .isRecruiting(false)
+                        .status(StatusType.NOTHING.getName())
                         .dateInfo(new DateInfoResponse(7, startAt, endAt))
                         .build();
 

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
@@ -194,7 +194,10 @@ public class Challenge extends BaseTime {
 
     private boolean isApproachingDeadline(final LocalDate startDate) {
         final LocalDate currentDate = LocalDate.now();
-        return currentDate.isAfter(startDate.minusDays(3)) && currentDate.isBefore(startDate);
+        final LocalDate DeadlineStart = startDate.minusDays(4);
+        final LocalDate afterStartDate = startDate.plusDays(1);
+
+        return currentDate.isAfter(DeadlineStart) && currentDate.isBefore(afterStartDate);
 
         // if (condition && isStartAt) return StatusType.COMING_SOON.getName();
         // else if (condition) return StatusType.APPROACHING_DEADLINE.getName();

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
@@ -198,18 +198,29 @@ public class Challenge extends BaseTime {
         final LocalDate afterStartDate = startDate.plusDays(1);
 
         return currentDate.isAfter(DeadlineStart) && currentDate.isBefore(afterStartDate);
-
-        // if (condition && isStartAt) return StatusType.COMING_SOON.getName();
-        // else if (condition) return StatusType.APPROACHING_DEADLINE.getName();
-
-        // return StatusType.NOTHING.getName();
     }
 
-    public String checkStatus(final LocalDate createdAt) {
-        // isRecruiting(this.getDuration().getStartAt());
+    private boolean isComingSoon(final LocalDate startDate) {
+        final LocalDate currentDate = LocalDate.now();
+        final LocalDate comingSoonStart = startDate.minusDays(8);
+        final LocalDate comingSoonEnd = startDate.minusDays(3);
+
+        return currentDate.isAfter(comingSoonStart) && currentDate.isBefore(comingSoonEnd);
+    }
+
+    public String checkStatusInChallengeDetail(final LocalDate createdAt) {
+        if (isComingSoon(createdAt)) return StatusType.COMING_SOON.getName();
+        if (isApproachingDeadline(this.getDuration().getStartAt()))
+            return StatusType.APPROACHING_DEADLINE.getName();
+
+        return StatusType.NOTHING.getName();
+    }
+
+    public String checkStatusInChallengeFeed(final LocalDate createdAt) {
         if (isNewChallenge(createdAt)) return StatusType.NEW.getName();
         if (isApproachingDeadline(this.getDuration().getStartAt()))
             return StatusType.APPROACHING_DEADLINE.getName();
+
         return StatusType.NOTHING.getName();
     }
 }

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
@@ -183,4 +183,30 @@ public class Challenge extends BaseTime {
     public List<String> getChallengeRuleContents() {
         return challengeRules.stream().map(ChallengeRule::getContent).collect(toList());
     }
+
+    private boolean isNewChallenge(final LocalDate createdAt) {
+        final LocalDate currentDate = LocalDate.now();
+        final LocalDate beforeCreatedAt = LocalDate.from(createdAt.minusDays(1));
+        final LocalDate untilNewDate = LocalDate.from(createdAt.plusDays(3));
+
+        return currentDate.isAfter(beforeCreatedAt) && currentDate.isBefore(untilNewDate);
+    }
+
+    private boolean isApproachingDeadline(final LocalDate startDate) {
+        final LocalDate currentDate = LocalDate.now();
+        return currentDate.isAfter(startDate.minusDays(3)) && currentDate.isBefore(startDate);
+
+        // if (condition && isStartAt) return StatusType.COMING_SOON.getName();
+        // else if (condition) return StatusType.APPROACHING_DEADLINE.getName();
+
+        // return StatusType.NOTHING.getName();
+    }
+
+    public String checkStatus(final LocalDate createdAt) {
+        // isRecruiting(this.getDuration().getStartAt());
+        if (isNewChallenge(createdAt)) return StatusType.NEW.getName();
+        if (isApproachingDeadline(this.getDuration().getStartAt()))
+            return StatusType.APPROACHING_DEADLINE.getName();
+        return StatusType.NOTHING.getName();
+    }
 }

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/StatusType.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/StatusType.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public enum StatusType {
     NEW("new"),
     APPROACHING_DEADLINE("마감임박"),
-    // COMING_SOON("오픈 예정"),
+    COMING_SOON("오픈 예정"),
     NOTHING("해당없음");
 
     private String name;

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/StatusType.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/StatusType.java
@@ -1,0 +1,18 @@
+package depromeet.domain.challenge.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public enum StatusType {
+    NEW("new"),
+    APPROACHING_DEADLINE("마감임박"),
+    // COMING_SOON("오픈 예정"),
+    NOTHING("해당없음");
+
+    private String name;
+}

--- a/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
@@ -1,0 +1,93 @@
+package depromeet.domain.challenge.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import depromeet.domain.challenge.domain.keyword.ChallengeKeywords;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ChallengeTest {
+
+    /*
+    챌린지 생성일 createdAt 이후 이틀 간 New 챌린지로 표시
+    기간 period가 5일이면, 챌린지 시작일 startAt = createdAt + period
+    */
+    @Test
+    @DisplayName("New 챌린지 - 오늘 생성된 챌린지")
+    public void isNewChallenge() {
+        int period = 5;
+        LocalDate startAt = LocalDate.now().plusDays(period);
+
+        Challenge challenge =
+                Challenge.createChallenge(
+                        "마라탕 5만원 이하로 쓰기",
+                        50000,
+                        "/test.jpg",
+                        mock(ChallengeKeywords.class),
+                        30,
+                        "socialId",
+                        new ArrayList<>(),
+                        mock(ChallengeCategories.class),
+                        new Duration(period, startAt, startAt.plusDays(period)));
+
+        assertThat(challenge.checkStatus(LocalDate.from(LocalDateTime.now())))
+                .isEqualTo(StatusType.NEW.getName());
+    }
+
+    /*
+    챌린지 시작일 startAt의 3일 전부터 마감임박 표시
+    챌린지 시작일 당일에는 참여 불가
+     */
+    @Test
+    @DisplayName("마감임박 챌린지")
+    public void isApproachingDeadline() {
+        int period = 5;
+        LocalDate createdAt = LocalDate.now().minusDays(3);
+        LocalDate startAt = createdAt.plusDays(period);
+
+        Challenge challenge =
+                Challenge.createChallenge(
+                        "마라탕 5만원 이하로 쓰기",
+                        50000,
+                        "/test.jpg",
+                        mock(ChallengeKeywords.class),
+                        30,
+                        "socialId",
+                        new ArrayList<>(),
+                        mock(ChallengeCategories.class),
+                        new Duration(period, startAt, startAt.plusDays(period)));
+
+        assertThat(challenge.checkStatus(LocalDate.from(createdAt)))
+                .isEqualTo(StatusType.APPROACHING_DEADLINE.getName());
+    }
+
+    @Test
+    @DisplayName("New 또는 마감임박에 해당하지 않는 챌린지")
+    public void isNotThing() {
+        int period = 5;
+        LocalDate createdAt = LocalDate.now().minusDays(10);
+        LocalDate startAt = createdAt.plusDays(period);
+
+        Challenge challenge =
+                Challenge.createChallenge(
+                        "마라탕 5만원 이하로 쓰기",
+                        50000,
+                        "/test.jpg",
+                        mock(ChallengeKeywords.class),
+                        30,
+                        "socialId",
+                        new ArrayList<>(),
+                        mock(ChallengeCategories.class),
+                        new Duration(period, startAt, startAt.plusDays(period)));
+
+        assertThat(challenge.checkStatus(LocalDate.from(createdAt)))
+                .isEqualTo(StatusType.NOTHING.getName());
+    }
+}

--- a/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
@@ -37,8 +37,34 @@ public class ChallengeTest {
                         mock(ChallengeCategories.class),
                         new Duration(period, startAt, startAt.plusDays(period)));
 
-        assertThat(challenge.checkStatus(LocalDate.from(LocalDateTime.now())))
+        assertThat(challenge.checkStatusInChallengeFeed(LocalDate.from(LocalDateTime.now())))
                 .isEqualTo(StatusType.NEW.getName());
+    }
+
+    /*
+    챌린지 모집 기간 일주일 중에서 초기 4일 동안을 오픈 예정으로 표시
+     */
+    @Test
+    @DisplayName("오픈예정 챌린지")
+    public void isComingSoon() {
+        int period = 5;
+        LocalDate createdAt = LocalDate.now().plusDays(4);
+        LocalDate startAt = createdAt.plusDays(7);
+
+        Challenge challenge =
+                Challenge.createChallenge(
+                        "마라탕 5만원 이하로 쓰기",
+                        50000,
+                        "/test.jpg",
+                        mock(ChallengeKeywords.class),
+                        30,
+                        "socialId",
+                        new ArrayList<>(),
+                        mock(ChallengeCategories.class),
+                        new Duration(period, startAt, startAt.plusDays(period)));
+
+        assertThat(challenge.checkStatusInChallengeDetail(LocalDate.from(createdAt)))
+                .isEqualTo(StatusType.COMING_SOON.getName());
     }
 
     /*
@@ -64,7 +90,7 @@ public class ChallengeTest {
                         mock(ChallengeCategories.class),
                         new Duration(period, startAt, startAt.plusDays(period)));
 
-        assertThat(challenge.checkStatus(LocalDate.from(createdAt)))
+        assertThat(challenge.checkStatusInChallengeDetail(LocalDate.from(createdAt)))
                 .isEqualTo(StatusType.APPROACHING_DEADLINE.getName());
     }
 
@@ -87,7 +113,7 @@ public class ChallengeTest {
                         mock(ChallengeCategories.class),
                         new Duration(period, startAt, startAt.plusDays(period)));
 
-        assertThat(challenge.checkStatus(LocalDate.from(createdAt)))
+        assertThat(challenge.checkStatusInChallengeDetail(LocalDate.from(createdAt)))
                 .isEqualTo(StatusType.NOTHING.getName());
     }
 }

--- a/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
@@ -17,13 +17,13 @@ public class ChallengeTest {
 
     /*
     챌린지 생성일 createdAt 이후 이틀 간 New 챌린지로 표시
-    기간 period가 5일이면, 챌린지 시작일 startAt = createdAt + period
+    챌린지 시작일 startAt = createdAt + 7
     */
     @Test
     @DisplayName("New 챌린지 - 오늘 생성된 챌린지")
     public void isNewChallenge() {
         int period = 5;
-        LocalDate startAt = LocalDate.now().plusDays(period);
+        LocalDate startAt = LocalDate.now().plusDays(7);
 
         Challenge challenge =
                 Challenge.createChallenge(
@@ -49,8 +49,8 @@ public class ChallengeTest {
     @DisplayName("마감임박 챌린지")
     public void isApproachingDeadline() {
         int period = 5;
-        LocalDate createdAt = LocalDate.now().minusDays(3);
-        LocalDate startAt = createdAt.plusDays(period);
+        LocalDate createdAt = LocalDate.now().minusDays(5);
+        LocalDate startAt = createdAt.plusDays(7);
 
         Challenge challenge =
                 Challenge.createChallenge(
@@ -73,7 +73,7 @@ public class ChallengeTest {
     public void isNotThing() {
         int period = 5;
         LocalDate createdAt = LocalDate.now().minusDays(10);
-        LocalDate startAt = createdAt.plusDays(period);
+        LocalDate startAt = createdAt.plusDays(7);
 
         Challenge challenge =
                 Challenge.createChallenge(


### PR DESCRIPTION
## 개요
- close #203 

## 작업사항
- 챌린지 상세 조회 시에는 `오픈 예정`, `마감 임박`을 사용한다.
- 챌린지 피드 조회 시에는 `new`, `마감 임박`을 사용한다.
- 테스트 코드 작성