### PR TITLE
[Bug] 자린고비 홈 조회 에러 해결

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/jalingobi/dto/JalingobiInfo.java
+++ b/Module-API/src/main/java/depromeet/api/domain/jalingobi/dto/JalingobiInfo.java
@@ -1,0 +1,30 @@
+package depromeet.api.domain.jalingobi.dto;
+
+
+import depromeet.domain.jalingobi.domain.Jalingobi;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class JalingobiInfo {
+    private Long jalingobiId;
+
+    private Integer level;
+
+    private String name;
+
+    private String acquisitionCondition;
+
+    public static JalingobiInfo createJalingobiInfo(Jalingobi jalingobi) {
+
+        return JalingobiInfo.builder()
+                .jalingobiId(jalingobi.getId())
+                .level(jalingobi.getLevel().getValue())
+                .name(jalingobi.getName())
+                .acquisitionCondition(jalingobi.getAcquisitionCondition())
+                .build();
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/jalingobi/dto/response/GetJalingobiResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/jalingobi/dto/response/GetJalingobiResponse.java
@@ -1,10 +1,12 @@
 package depromeet.api.domain.jalingobi.dto.response;
 
 
+import depromeet.api.domain.jalingobi.dto.JalingobiInfo;
 import depromeet.domain.jalingobi.domain.Jalingobi;
 import depromeet.domain.jalingobi.domain.Level;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,15 +14,21 @@ import lombok.Getter;
 @Builder
 public class GetJalingobiResponse {
     @Schema(description = "전체 자린고비 정보 리스트")
-    private List<Jalingobi> jalingobiList;
+    private List<JalingobiInfo> jalingobiList;
 
-    @Schema(description = "현재 사용자 자린고비 레벨")
-    private Level userLevel;
+    @Schema(description = "현재 사용자 자린고비 레벨", example = "1")
+    private Integer userLevel;
 
     public static GetJalingobiResponse of(List<Jalingobi> jalingobiList, Level userLevel) {
+
+        List<JalingobiInfo> newJalingobiList =
+                jalingobiList.stream()
+                        .map(JalingobiInfo::createJalingobiInfo)
+                        .collect(Collectors.toList());
+
         return GetJalingobiResponse.builder()
-                .jalingobiList(jalingobiList)
-                .userLevel(userLevel)
+                .jalingobiList(newJalingobiList)
+                .userLevel(userLevel.getValue())
                 .build();
     }
 }

--- a/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Jalingobi.java
+++ b/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Jalingobi.java
@@ -1,7 +1,6 @@
 package depromeet.domain.jalingobi.domain;
 
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
@@ -34,6 +33,5 @@ public class Jalingobi {
     private String acquisitionCondition;
 
     @OneToMany(mappedBy = "jalingobi", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    @JsonIgnore
     private List<SmallTalk> smallTalks = new ArrayList<>();
 }

--- a/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Jalingobi.java
+++ b/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Jalingobi.java
@@ -1,6 +1,7 @@
 package depromeet.domain.jalingobi.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
@@ -33,5 +34,6 @@ public class Jalingobi {
     private String acquisitionCondition;
 
     @OneToMany(mappedBy = "jalingobi", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JsonIgnore
     private List<SmallTalk> smallTalks = new ArrayList<>();
 }

--- a/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Level.java
+++ b/Module-Domain/src/main/java/depromeet/domain/jalingobi/domain/Level.java
@@ -9,15 +9,16 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Level {
-    LEVEL_0(0),
-    LEVEL_1(1),
-    LEVEL_2(2),
-    LEVEL_3(3),
-    LEVEL_4(4),
-    LEVEL_5(5),
-    LEVEL_6(6);
+    LEVEL_0(0, 0),
+    LEVEL_1(1, 1),
+    LEVEL_2(2, 2),
+    LEVEL_3(3, 3),
+    LEVEL_4(4, 4),
+    LEVEL_5(5, 5),
+    LEVEL_6(6, 6);
 
     private final int score;
+    private final int value;
 
     public static Level getEnumTypeByScore(int score) {
         return Arrays.stream(Level.values())


### PR DESCRIPTION
## 개요
- close #221 

## 작업사항
- 자린고비 홈 조회 api 버그 수정

- 와~ 멋진 에러다 ㅎ.. 진짜 로그보고 식겁했어요..저거보다 더 길어..
- 무한 순환 참조(Recursive Reference) 에러였어용
- Jalingobi 객체의 smallTalks 속성과 SmallTalk 객체의 jalingobi 속성 간에 서로 참조가 순환되고 있어서 Jackson 라이브러리가 JSON 직렬화를 수행할 수 없어서 발생하는 문제.
- 자린고비 조회할 때 어차피 small talk 필요없어서 `@JsonIgnore` 로 해결했습니당.. 머쓱타드 JPA 보초

![image](https://github.com/depromeet/jalingobi-server/assets/97580782/64e1fb62-39ec-418a-a76a-f51e25a6668c)
