### PR TITLE
[Refactor] 챌린지 기록 응답 값, 기록 생성, 삭제, 수정 시 currentCharge 값 변경

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/record/controller/RecordController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/controller/RecordController.java
@@ -34,7 +34,7 @@ public class RecordController {
     private final DeleteRecordUseCase deleteRecordUseCase;
 
     @Operation(summary = "챌린지 지출을 기록하는 API")
-    @PostMapping("/{challengeId}/create")
+    @PostMapping("/{challengeId}")
     public Response<CreateRecordResponse> createRecord(
             @PathVariable Long challengeId,
             @RequestBody @Valid CreateRecordRequest createRecordRequest) {

--- a/Module-API/src/main/java/depromeet/api/domain/record/controller/RecordController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/controller/RecordController.java
@@ -3,6 +3,7 @@ package depromeet.api.domain.record.controller;
 import static depromeet.api.util.AuthenticationUtil.getCurrentUserSocialId;
 
 import depromeet.api.domain.record.dto.request.CreateRecordRequest;
+import depromeet.api.domain.record.dto.request.UpdateRecordRequest;
 import depromeet.api.domain.record.dto.response.CreateRecordResponse;
 import depromeet.api.domain.record.dto.response.GetRecordResponse;
 import depromeet.api.domain.record.usecase.CreateRecordUseCase;
@@ -66,7 +67,7 @@ public class RecordController {
     @PatchMapping("/{recordId}")
     public Response<CustomExceptionStatus> updateRecord(
             @PathVariable Long recordId,
-            @RequestBody @Valid CreateRecordRequest updateRecordRequest) {
+            @RequestBody @Valid UpdateRecordRequest updateRecordRequest) {
 
         updateRecordUseCase.execute(recordId, getCurrentUserSocialId(), updateRecordRequest);
         return ResponseService.getDataResponse(CustomExceptionStatus.SUCCESS);

--- a/Module-API/src/main/java/depromeet/api/domain/record/dto/request/UpdateRecordRequest.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/dto/request/UpdateRecordRequest.java
@@ -1,0 +1,42 @@
+package depromeet.api.domain.record.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateRecordRequest {
+
+    @Schema(minimum = "0", maximum = "999999", example = "지출 비용")
+    @NotNull(message = "지출 비용을 입력해주세요.")
+    @Range(min = 0, max = 999999, message = "지출 비용은 0부터 999999까지 입력 가능합니다.")
+    private Integer price;
+
+    @Schema(minimum = "1", maximum = "16", example = "지출 명")
+    @NotBlank(message = "지출 명을 입력해주세요.")
+    @Size(min = 1, max = 16, message = "지출 명은 16자 이하입니다.")
+    private String title;
+
+    @Schema(minimum = "1", maximum = "80", example = "지출 내용")
+    @NotBlank(message = "내용을 입력해주세요.")
+    @Size(min = 1, max = 80, message = "내용은 80자 이하입니다.")
+    private String content;
+
+    @Schema(nullable = true, example = "지출 사진 링크")
+    private String imgUrl;
+
+    @Schema(description = "지출 평가, [1,2,3,4] 중에서 선택 가능합니다.")
+    @NotNull(message = "지출 평가를 입력해주세요.")
+    @Range(min = 1, max = 4, message = "점수는 1부터 4까지 입니다.")
+    private Integer evaluation;
+}

--- a/Module-API/src/main/java/depromeet/api/domain/record/dto/response/CreateRecordResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/dto/response/CreateRecordResponse.java
@@ -2,28 +2,49 @@ package depromeet.api.domain.record.dto.response;
 
 
 import depromeet.domain.record.domain.Record;
-import depromeet.domain.user.domain.User;
+import depromeet.domain.userchallenge.domain.UserChallenge;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
-@Getter
 @Builder
+@AllArgsConstructor
+@Getter
 public class CreateRecordResponse {
-    private final Long id;
+    private Long id;
     private String title;
-    private final String content;
-    private final String imgUrl;
-    private final int evaluation;
-    private final User user;
+    private String content;
+    private String imgUrl;
+    private Integer evaluation;
+    private RecordUserInfo userInfo;
 
-    public static CreateRecordResponse of(Record record, User user) {
+    public static CreateRecordResponse of(Record record) {
+
+        RecordUserInfo userInfo = new RecordUserInfo(record.getUserChallenge());
+
         return CreateRecordResponse.builder()
                 .id(record.getId())
                 .title(record.getTitle())
                 .content(record.getContent())
                 .imgUrl(record.getImgUrl())
                 .evaluation(record.getEvaluation().getValue())
-                .user(user)
+                .userInfo(userInfo)
                 .build();
+    }
+
+    @Data
+    private static class RecordUserInfo {
+        @Schema(example = "사용자 닉네임")
+        private String nickname;
+
+        @Schema(example = "사용자 이미지 URL")
+        private String userImgUrl;
+
+        public RecordUserInfo(UserChallenge userChallenge) {
+            this.nickname = userChallenge.getNickname();
+            this.userImgUrl = userChallenge.getImgUrl();
+        }
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/record/mapper/RecordMapper.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/mapper/RecordMapper.java
@@ -32,8 +32,8 @@ public class RecordMapper {
                 Evaluation.getEnumTypeByValue(createRecordRequest.getEvaluation()));
     }
 
-    public CreateRecordResponse toCreateRecordResponse(Record record, User user) {
-        return CreateRecordResponse.of(record, user);
+    public CreateRecordResponse toCreateRecordResponse(Record record) {
+        return CreateRecordResponse.of(record);
     }
 
     public GetRecordResponse toGetRecordResponse(Record record, Long myUserChallengeId) {

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
@@ -34,10 +34,11 @@ public class CreateRecordUseCase {
 
         User currentUser = userAdaptor.findUser(socialId);
         Challenge challenge = challengeAdaptor.findChallenge(challengeId);
+        recordValidator.validateUnparticipatedChallenge(socialId, challenge);
+
         UserChallenge userChallenge =
                 userChallengeAdaptor.findUserChallenge(challenge, currentUser);
-
-        recordValidator.validateUnparticipatedChallenge(socialId, challenge);
+        userChallenge.addCharge(createRecordRequest.getPrice());
 
         Record record =
                 recordAdaptor.save(

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
@@ -44,6 +44,6 @@ public class CreateRecordUseCase {
                         recordMapper.toEntity(
                                 challenge, currentUser, userChallenge, createRecordRequest));
 
-        return recordMapper.toCreateRecordResponse(record, currentUser);
+        return recordMapper.toCreateRecordResponse(record);
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/DeleteRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/DeleteRecordUseCase.java
@@ -5,6 +5,7 @@ import depromeet.api.domain.record.validator.RecordValidator;
 import depromeet.common.annotation.UseCase;
 import depromeet.domain.record.adaptor.RecordAdaptor;
 import depromeet.domain.record.domain.Record;
+import depromeet.domain.userchallenge.domain.UserChallenge;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,13 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class DeleteRecordUseCase {
+
     private final RecordAdaptor recordAdaptor;
     private final RecordValidator recordValidator;
 
     public void execute(Long recordId, String socialId) {
-        Record record = recordAdaptor.findRecord(recordId);
 
+        Record record = recordAdaptor.findRecord(recordId);
         recordValidator.validateCorrectUserRecord(record, socialId);
+
+        UserChallenge userChallenge = record.getUserChallenge();
+        userChallenge.removeCharge(record.getPrice());
 
         recordAdaptor.deleteRecord(recordId);
     }

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
@@ -2,7 +2,7 @@ package depromeet.api.domain.record.usecase;
 
 
 import depromeet.api.config.s3.S3UploadPresignedUrlService;
-import depromeet.api.domain.record.dto.request.CreateRecordRequest;
+import depromeet.api.domain.record.dto.request.UpdateRecordRequest;
 import depromeet.api.domain.record.validator.RecordValidator;
 import depromeet.common.annotation.UseCase;
 import depromeet.domain.record.adaptor.RecordAdaptor;
@@ -23,7 +23,7 @@ public class UpdateRecordUseCase {
     private final RecordValidator recordValidator;
     private final S3UploadPresignedUrlService uploadPresignedUrlService;
 
-    public void execute(Long recordId, String socialId, CreateRecordRequest updateRecordRequest) {
+    public void execute(Long recordId, String socialId, UpdateRecordRequest updateRecordRequest) {
         Record record = recordAdaptor.findRecord(recordId);
 
         recordValidator.validateCorrectUserRecord(record, socialId);

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
@@ -7,9 +7,8 @@ import depromeet.api.domain.record.validator.RecordValidator;
 import depromeet.common.annotation.UseCase;
 import depromeet.domain.record.adaptor.RecordAdaptor;
 import depromeet.domain.record.domain.Record;
-import java.util.Optional;
-
 import depromeet.domain.userchallenge.domain.UserChallenge;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
@@ -8,6 +8,8 @@ import depromeet.common.annotation.UseCase;
 import depromeet.domain.record.adaptor.RecordAdaptor;
 import depromeet.domain.record.domain.Record;
 import java.util.Optional;
+
+import depromeet.domain.userchallenge.domain.UserChallenge;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +36,9 @@ public class UpdateRecordUseCase {
             String key = getKey(imgUrl);
             uploadPresignedUrlService.deleteImage(key);
         }
+        UserChallenge userChallenge = record.getUserChallenge();
+        userChallenge.removeCharge(record.getPrice());
+        userChallenge.addCharge(updateRecordRequest.getPrice());
 
         record.updateRecord(
                 updateRecordRequest.getPrice(),

--- a/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
@@ -137,7 +137,7 @@ class RecordControllerTest {
                         .build();
 
         MockHttpServletRequestBuilder requestBuilder =
-                MockMvcRequestBuilders.post("/record/{challengeId}/create", 1)
+                MockMvcRequestBuilders.post("/record/{challengeId}", 1)
                         .with(csrf())
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(createRecordRequest))

--- a/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/record/controller/RecordControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import depromeet.api.config.security.filter.JwtRequestFilter;
 import depromeet.api.domain.record.dto.request.CreateRecordRequest;
+import depromeet.api.domain.record.dto.request.UpdateRecordRequest;
 import depromeet.api.domain.record.dto.response.CreateRecordResponse;
 import depromeet.api.domain.record.usecase.CreateRecordUseCase;
 import depromeet.api.domain.record.usecase.DeleteRecordUseCase;
@@ -98,7 +99,7 @@ class RecordControllerTest {
                         .build();
 
         MockHttpServletRequestBuilder requestBuilder =
-                MockMvcRequestBuilders.post("/record/{challengeId}/create", 1)
+                MockMvcRequestBuilders.post("/record/{challengeId}", 1)
                         .with(csrf())
                         .content(objectMapper.writeValueAsString(createRecordRequest))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -161,8 +162,8 @@ class RecordControllerTest {
     @DisplayName("[PATCH] 챌린지 기록 수정")
     public void UpdateRecordTest() throws Exception {
         // given
-        CreateRecordRequest updateRecordRequest =
-                CreateRecordRequest.builder()
+        UpdateRecordRequest updateRecordRequest =
+                UpdateRecordRequest.builder()
                         .price(4000)
                         .title("커피")
                         .content("커피는 맛있어")

--- a/Module-Common/src/main/java/depromeet/common/exception/CustomExceptionStatus.java
+++ b/Module-Common/src/main/java/depromeet/common/exception/CustomExceptionStatus.java
@@ -58,6 +58,7 @@ public enum CustomExceptionStatus {
     RECORD_NOT_FOUND(false, 2000, "유효하지 않은 평가 점수입니다."),
     RECORD_EVALUATION_NOT_VALID(false, 2001, "유효하지 않은 평가 점수입니다."),
     INVALID_RECORD_USER(false, 2002, "해당 지출을 기록한 사용자가 아닙니다."),
+    CHARGE_CANNOT_BE_NEGATIVE(false, 2003, "현재 지출 비용은 마이너스 값이 될 수 없습니다."),
 
     // category
     CATEGORY_NOT_FOUND(false, 2100, "존재하지 않는 카테고리입니다."),

--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
@@ -6,6 +6,7 @@ import depromeet.domain.config.BaseTime;
 import depromeet.domain.jalingobi.domain.Level;
 import depromeet.domain.record.domain.Record;
 import depromeet.domain.user.domain.User;
+import depromeet.domain.userchallenge.exception.NegativeChargeException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
@@ -66,5 +67,17 @@ public class UserChallenge extends BaseTime {
 
     public int getUserLevel() {
         return Level.getEnumTypeByScore(this.getUser().getScore()).getScore();
+    }
+
+    public void addCharge(int price) {
+        this.currentCharge += price;
+    }
+
+    public void removeCharge(int price) {
+        int rest = this.currentCharge - price;
+        if (rest < 0) {
+            throw NegativeChargeException.EXCEPTION;
+        }
+        this.currentCharge = rest;
     }
 }

--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/exception/NegativeChargeException.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/exception/NegativeChargeException.java
@@ -1,0 +1,13 @@
+package depromeet.domain.userchallenge.exception;
+
+
+import depromeet.common.exception.CustomException;
+import depromeet.common.exception.CustomExceptionStatus;
+
+public class NegativeChargeException extends CustomException {
+    public static final CustomException EXCEPTION = new NegativeChargeException();
+
+    private NegativeChargeException() {
+        super(CustomExceptionStatus.CHARGE_CANNOT_BE_NEGATIVE);
+    }
+}


### PR DESCRIPTION
## 개요
- close #230

## 작업사항
- [x] 수정하는 DTO 분리
- [x] 챌린지 기록 endpoint 수정
- [x] 챌린지 기록 response에 엔티티로 되어 있는 부분 DTO로 수정
- [x] 챌린지 기록 후 response 줄 때 User 정보가 아니라 UserChallenge 내의 유저의 커스텀 정보를 넘겨줘야함
- [x] 사용자가 지출을 기록할 때 `currentCharge` 값 변경
- [x] 사용자가 지출을 수정할 때 `currentCharge` 값 변경
- [x] 사용자가 지출을 삭제할 때 `currentCharge` 값 변경