### PR TITLE
[Feature] 챌린지 탐색 구현

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/controller/ChallengeFeedController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/controller/ChallengeFeedController.java
@@ -1,0 +1,31 @@
+package depromeet.api.domain.challenge.controller;
+
+
+import depromeet.api.domain.challenge.usecase.GetChallengeInfiniteScrollFeedUseCase;
+import depromeet.common.response.Response;
+import depromeet.common.response.ResponseService;
+import depromeet.domain.challenge.domain.ChallengeSlice;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChallengeFeedController {
+
+    private final GetChallengeInfiniteScrollFeedUseCase getChallengeInfiniteScrollFeedUseCase;
+
+    @GetMapping("/challenge/search")
+    public Response<ChallengeSlice> searchChallenges(
+            @RequestParam(required = false) final String category,
+            @RequestParam(required = false, defaultValue = "recruit") String filter,
+            @RequestParam(required = false) String sortType,
+            @PageableDefault final Pageable pageable) {
+        return ResponseService.getDataResponse(
+                getChallengeInfiniteScrollFeedUseCase.execute(
+                        category, filter, sortType, pageable));
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/feed/ChallengeFeedResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/feed/ChallengeFeedResponse.java
@@ -1,0 +1,32 @@
+package depromeet.api.domain.challenge.dto.response.feed;
+
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeFeedResponse {
+
+    private Long challengeId;
+
+    private Integer curCount;
+
+    private Integer availableCount;
+
+    private String title;
+
+    private String imgUrl;
+
+    private List<String> keywords;
+
+    private LocalDate startAt;
+
+    private Integer period;
+}

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/feed/ChallengeInfiniteScrollResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/feed/ChallengeInfiniteScrollResponse.java
@@ -1,0 +1,18 @@
+package depromeet.api.domain.challenge.dto.response.feed;
+
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeInfiniteScrollResponse {
+
+    private List<ChallengeFeedResponse> data;
+    private Boolean hasNext;
+}

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/GetChallengeInfiniteScrollFeedUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/GetChallengeInfiniteScrollFeedUseCase.java
@@ -1,0 +1,32 @@
+package depromeet.api.domain.challenge.usecase;
+
+
+import depromeet.common.annotation.UseCase;
+import depromeet.domain.challenge.domain.ChallengeSearchCondition;
+import depromeet.domain.challenge.domain.ChallengeSlice;
+import depromeet.domain.challenge.repository.ChallengeData;
+import depromeet.domain.challenge.repository.ChallengeQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetChallengeInfiniteScrollFeedUseCase {
+
+    private final ChallengeQueryRepository challengeQueryRepository;
+
+    public ChallengeSlice execute(
+            final String category,
+            final String filter,
+            final String sortType,
+            final Pageable pageable) {
+        final ChallengeSearchCondition condition =
+                new ChallengeSearchCondition(category, filter, sortType);
+        final Slice<ChallengeData> challengeData =
+                challengeQueryRepository.searchBy(condition, pageable);
+        return new ChallengeSlice(challengeData.getContent(), challengeData.hasNext());
+    }
+}

--- a/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeFeedControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeFeedControllerTest.java
@@ -1,0 +1,73 @@
+package depromeet.api.domain.challenge.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import depromeet.api.config.security.filter.JwtRequestFilter;
+import depromeet.api.domain.challenge.usecase.GetChallengeInfiniteScrollFeedUseCase;
+import depromeet.domain.challenge.domain.ChallengeSlice;
+import depromeet.domain.challenge.repository.ChallengeData;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(
+        controllers = ChallengeFeedController.class,
+        excludeFilters = {
+            @ComponentScan.Filter(
+                    type = FilterType.ASSIGNABLE_TYPE,
+                    classes = {JwtRequestFilter.class})
+        })
+@AutoConfigureDataJpa
+@AutoConfigureMockMvc(addFilters = false)
+public class ChallengeFeedControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockBean GetChallengeInfiniteScrollFeedUseCase getChallengeInfiniteScrollFeedUseCase;
+
+    @Test
+    @DisplayName("챌린지 탐색")
+    public void searchChallenge() throws Exception {
+        String category = "식비";
+        String filter = "all";
+        String sortType = "price";
+        ChallengeData challengeData =
+                new ChallengeData(
+                        1L, "마라탕 10만원 이하로 쓰기", 2, 10, "/test.jpg", 100000, LocalDate.now(), 5);
+        List<ChallengeData> data = new ArrayList<>();
+        data.add(challengeData);
+        ChallengeSlice challengeSlice = new ChallengeSlice(data, true);
+
+        when(getChallengeInfiniteScrollFeedUseCase.execute(
+                        anyString(), anyString(), anyString(), any()))
+                .thenReturn(challengeSlice);
+
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/challenge/search")
+                                .param("category", category)
+                                .param("filter", filter)
+                                .param("sortType", sortType))
+                .andDo(print())
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.result.challenges", hasSize(1)),
+                        jsonPath("$.result.hasNext").value(true));
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/ChallengeSearchCondition.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/ChallengeSearchCondition.java
@@ -1,0 +1,14 @@
+package depromeet.domain.challenge.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChallengeSearchCondition {
+
+    private String category;
+    private String filter;
+    private String sortType;
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/ChallengeSlice.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/ChallengeSlice.java
@@ -1,0 +1,18 @@
+package depromeet.domain.challenge.domain;
+
+
+import depromeet.domain.challenge.repository.ChallengeData;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ChallengeSlice {
+
+    private List<ChallengeData> challenges;
+    private boolean hasNext;
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeData.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeData.java
@@ -1,0 +1,49 @@
+package depromeet.domain.challenge.repository;
+
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChallengeData {
+
+    private long id;
+    private String title;
+    private int currentPeopleCount;
+    private int availablePeopleCount;
+    private String imgUrl;
+    private int price;
+    private List<String> keywords;
+    private LocalDate startAt;
+    private int period;
+    private String status;
+
+    public ChallengeData(
+            long id,
+            String title,
+            int currentPeopleCount,
+            int availablePeopleCount,
+            String imgUrl,
+            int price,
+            LocalDate startAt,
+            int period) {
+        this.id = id;
+        this.title = title;
+        this.currentPeopleCount = currentPeopleCount;
+        this.availablePeopleCount = availablePeopleCount;
+        this.imgUrl = imgUrl;
+        this.price = price;
+        this.startAt = startAt;
+        this.period = period;
+    }
+
+    public void setKeywordNames(List<String> keywordNames) {
+        this.keywords = keywordNames;
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeQueryRepository.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeQueryRepository.java
@@ -1,0 +1,116 @@
+package depromeet.domain.challenge.repository;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static depromeet.domain.category.domain.QCategory.category;
+import static depromeet.domain.challenge.domain.QChallenge.challenge;
+import static depromeet.domain.challenge.domain.QChallengeCategory.challengeCategory;
+import static depromeet.domain.challenge.domain.keyword.QChallengeKeyword.challengeKeyword;
+import static depromeet.domain.keyword.domain.QKeyword.keyword1;
+
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import depromeet.domain.challenge.domain.ChallengeSearchCondition;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChallengeQueryRepository {
+
+    private static final String PRICE = "price";
+
+    private final JPAQueryFactory queryFactory;
+    private final ConditionFilter conditionFilter = new ConditionFilter();
+
+    public Slice<ChallengeData> searchBy(ChallengeSearchCondition condition, Pageable pageable) {
+        final List<ChallengeData> challenges =
+                queryFactory
+                        .select(makeProjections())
+                        .from(challenge)
+                        .where(conditionFilter.filterByCondition(condition))
+                        .join(challenge.challengeCategories.challengeCategories, challengeCategory)
+                        .join(challengeCategory.category, category)
+                        .distinct()
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize() + 1)
+                        .orderBy(
+                                orderByCondition(condition.getSortType())
+                                        .toArray(OrderSpecifier[]::new))
+                        .fetch();
+
+        setKeywordName(challenges);
+
+        return new SliceImpl<>(
+                getCurrentPageChallenges(challenges, pageable),
+                pageable,
+                hasNext(challenges, pageable));
+    }
+
+    private Map<Long, List<String>> findKeywordNameMap(List<Long> challengeIds) {
+        return queryFactory
+                .from(challenge)
+                .leftJoin(challenge.challengeKeywords.challengeKeywords, challengeKeyword)
+                .leftJoin(challengeKeyword.keyword, keyword1)
+                .where(challenge.id.in(challengeIds))
+                .transform(groupBy(challenge.id).as(GroupBy.list(keyword1.keyword)));
+    }
+
+    private void setKeywordName(List<ChallengeData> fetch) {
+        List<Long> challengeIds = toChallengeIds(fetch);
+        Map<Long, List<String>> keywordNameMap = findKeywordNameMap(challengeIds);
+        fetch.forEach(o -> o.setKeywordNames(keywordNameMap.get(o.getId())));
+    }
+
+    private List<Long> toChallengeIds(List<ChallengeData> result) {
+        return result.stream().map(ChallengeData::getId).collect(Collectors.toList());
+    }
+
+    private static ConstructorExpression<ChallengeData> makeProjections() {
+        return Projections.constructor(
+                ChallengeData.class,
+                challenge.id,
+                challenge.title,
+                challenge.userChallenges.size(),
+                challenge.availableCount,
+                challenge.imgUrl,
+                challenge.price,
+                challenge.duration.startAt,
+                challenge.duration.period);
+    }
+
+    private List<OrderSpecifier<?>> orderByCondition(String sortType) {
+        List<OrderSpecifier<?>> orderBy = new LinkedList<>();
+
+        if (sortType.equals(PRICE)) {
+            orderBy.add(challenge.price.desc());
+        } else {
+            orderBy.add(challenge.availableCount.desc());
+        }
+
+        orderBy.add(challenge.title.asc());
+
+        return orderBy;
+    }
+
+    private List<ChallengeData> getCurrentPageChallenges(
+            final List<ChallengeData> challenges, final Pageable pageable) {
+        if (hasNext(challenges, pageable)) {
+            return challenges.subList(0, challenges.size() - 1);
+        }
+        return challenges;
+    }
+
+    private boolean hasNext(final List<ChallengeData> challenges, final Pageable pageable) {
+        return challenges.size() > pageable.getPageSize();
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ConditionFilter.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ConditionFilter.java
@@ -1,0 +1,59 @@
+package depromeet.domain.challenge.repository;
+
+import static depromeet.domain.challenge.domain.QChallenge.challenge;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import depromeet.domain.challenge.domain.CategoryType;
+import depromeet.domain.challenge.domain.ChallengeSearchCondition;
+import java.time.LocalDate;
+
+public class ConditionFilter {
+
+    private static final String RECRUIT = "recruit";
+    private static final String ALL = "all";
+
+    public BooleanBuilder filterByCondition(ChallengeSearchCondition condition) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+        filterByCategory(booleanBuilder, condition.getCategory());
+        isRecruiting(booleanBuilder, condition.getFilter());
+        allExcludeFinished(booleanBuilder, condition.getFilter()); // 모집 중 + 진행 중
+
+        return booleanBuilder;
+    }
+
+    private void filterByCategory(BooleanBuilder booleanBuilder, String category) {
+        if (!category.isBlank()) {
+            CategoryType categoryType = CategoryType.of(category);
+            booleanBuilder.and(
+                    challenge
+                            .challengeCategories
+                            .challengeCategories
+                            .any()
+                            .category
+                            .name
+                            .eq(String.valueOf(categoryType)));
+        }
+    }
+
+    private void isRecruiting(BooleanBuilder booleanBuilder, String filter) {
+        if (filter.equals(RECRUIT)) {
+            booleanBuilder.and(beforeStarted());
+        }
+    }
+
+    private void allExcludeFinished(BooleanBuilder booleanBuilder, String filter) {
+        if (filter.equals(ALL)) {
+            booleanBuilder.and(beforeEnd());
+        }
+    }
+
+    private BooleanExpression beforeStarted() {
+        return challenge.duration.startAt.lt(LocalDate.now());
+    }
+
+    private BooleanExpression beforeEnd() {
+        return challenge.duration.endAt.goe(LocalDate.now());
+    }
+}


### PR DESCRIPTION
## 개요
- close #121 

## 작업사항
- Querydsl-JPA를 이용한 챌린지 탐색 구현
- 챌린지 탐색 API 테스트 코드 작성