### PR TITLE
[Feature] 챌린지 탐색 DTO에 챌린지 상태 정보 필드 추가

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/GetChallengeInfiniteScrollFeedUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/GetChallengeInfiniteScrollFeedUseCase.java
@@ -1,11 +1,13 @@
 package depromeet.api.domain.challenge.usecase;
 
 
+import depromeet.api.util.ChallengeStatusUtil;
 import depromeet.common.annotation.UseCase;
 import depromeet.domain.challenge.domain.ChallengeSearchCondition;
 import depromeet.domain.challenge.domain.ChallengeSlice;
 import depromeet.domain.challenge.repository.ChallengeData;
 import depromeet.domain.challenge.repository.ChallengeQueryRepository;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetChallengeInfiniteScrollFeedUseCase {
 
     private final ChallengeQueryRepository challengeQueryRepository;
+    private final ChallengeStatusUtil challengeStatusUtil;
 
     public ChallengeSlice execute(
             final String category,
@@ -27,6 +30,11 @@ public class GetChallengeInfiniteScrollFeedUseCase {
                 new ChallengeSearchCondition(category, filter, sortType);
         final Slice<ChallengeData> challengeData =
                 challengeQueryRepository.searchBy(condition, pageable);
+        challengeData.forEach(
+                data ->
+                        data.setChallengeStatus(
+                                challengeStatusUtil.checkStatusInChallengeFeed(
+                                        LocalDate.from(data.getCreatedAt()), data.getStartAt())));
         return new ChallengeSlice(challengeData.getContent(), challengeData.hasNext());
     }
 }

--- a/Module-API/src/main/java/depromeet/api/util/ChallengeStatusUtil.java
+++ b/Module-API/src/main/java/depromeet/api/util/ChallengeStatusUtil.java
@@ -1,0 +1,33 @@
+package depromeet.api.util;
+
+
+import depromeet.common.annotation.Util;
+import depromeet.domain.challenge.domain.StatusType;
+import java.time.LocalDate;
+
+@Util
+public class ChallengeStatusUtil {
+
+    private boolean isNewChallenge(final LocalDate createdAt) {
+        final LocalDate currentDate = LocalDate.now();
+        final LocalDate beforeCreatedAt = LocalDate.from(createdAt.minusDays(1));
+        final LocalDate untilNewDate = LocalDate.from(createdAt.plusDays(3));
+
+        return currentDate.isAfter(beforeCreatedAt) && currentDate.isBefore(untilNewDate);
+    }
+
+    private boolean isApproachingDeadline(final LocalDate startDate) {
+        final LocalDate currentDate = LocalDate.now();
+        final LocalDate DeadlineStart = startDate.minusDays(4);
+        final LocalDate afterStartDate = startDate.plusDays(1);
+
+        return currentDate.isAfter(DeadlineStart) && currentDate.isBefore(afterStartDate);
+    }
+
+    public String checkStatusInChallengeFeed(final LocalDate createdAt, final LocalDate startedAt) {
+        if (isNewChallenge(createdAt)) return StatusType.NEW.getName();
+        if (isApproachingDeadline(startedAt)) return StatusType.APPROACHING_DEADLINE.getName();
+
+        return StatusType.NOTHING.getName();
+    }
+}

--- a/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeFeedControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeFeedControllerTest.java
@@ -13,6 +13,7 @@ import depromeet.api.domain.challenge.usecase.GetChallengeInfiniteScrollFeedUseC
 import depromeet.domain.challenge.domain.ChallengeSlice;
 import depromeet.domain.challenge.repository.ChallengeData;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -50,7 +51,15 @@ public class ChallengeFeedControllerTest {
         String sortType = "price";
         ChallengeData challengeData =
                 new ChallengeData(
-                        1L, "마라탕 10만원 이하로 쓰기", 2, 10, "/test.jpg", 100000, LocalDate.now(), 5);
+                        1L,
+                        "마라탕 10만원 이하로 쓰기",
+                        2,
+                        10,
+                        "/test.jpg",
+                        100000,
+                        LocalDate.now(),
+                        LocalDateTime.now().minusDays(7),
+                        5);
         List<ChallengeData> data = new ArrayList<>();
         data.add(challengeData);
         ChallengeSlice challengeSlice = new ChallengeSlice(data, true);

--- a/Module-API/src/test/java/depromeet/api/util/ChallengeStatusUtilTest.java
+++ b/Module-API/src/test/java/depromeet/api/util/ChallengeStatusUtilTest.java
@@ -1,0 +1,100 @@
+package depromeet.api.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import depromeet.domain.challenge.domain.StatusType;
+import depromeet.domain.challenge.repository.ChallengeData;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ChallengeStatusUtilTest {
+
+    ChallengeStatusUtil challengeStatusUtil = new ChallengeStatusUtil();
+
+    /*
+    챌린지 생성일 createdAt 이후 이틀 간 New 챌린지로 표시
+    챌린지 시작일 startAt = createdAt + 7
+    */
+    @Test
+    @DisplayName("New 챌린지 - 오늘 생성된 챌린지")
+    public void isNewChallenge() {
+        int period = 5;
+        LocalDate startAt = LocalDate.now().plusDays(7);
+
+        ChallengeData challenge =
+                new ChallengeData(
+                        1L,
+                        "마라탕 5만원 이하로 쓰기",
+                        10,
+                        30,
+                        "/test.jpg",
+                        50000,
+                        startAt,
+                        LocalDateTime.now(),
+                        period);
+
+        assertThat(
+                        challengeStatusUtil.checkStatusInChallengeFeed(
+                                LocalDate.from(LocalDateTime.now()), challenge.getStartAt()))
+                .isEqualTo(StatusType.NEW.getName());
+    }
+
+    /*
+    챌린지 시작일 startAt의 3일 전부터 마감임박 표시
+    챌린지 시작일 당일에는 참여 불가
+     */
+    @Test
+    @DisplayName("마감임박 챌린지")
+    public void isApproachingDeadline() {
+        int period = 5;
+        LocalDate createdAt = LocalDate.now().minusDays(5);
+        LocalDate startAt = createdAt.plusDays(7);
+
+        ChallengeData challenge =
+                new ChallengeData(
+                        1L,
+                        "마라탕 5만원 이하로 쓰기",
+                        10,
+                        30,
+                        "/test.jpg",
+                        50000,
+                        startAt,
+                        LocalDateTime.now(),
+                        period);
+
+        assertThat(
+                        challengeStatusUtil.checkStatusInChallengeFeed(
+                                LocalDate.from(createdAt), challenge.getStartAt()))
+                .isEqualTo(StatusType.APPROACHING_DEADLINE.getName());
+    }
+
+    @Test
+    @DisplayName("New 또는 마감임박에 해당하지 않는 챌린지")
+    public void isNotThing() {
+        int period = 5;
+        LocalDate createdAt = LocalDate.now().minusDays(10);
+        LocalDate startAt = createdAt.plusDays(7);
+
+        ChallengeData challenge =
+                new ChallengeData(
+                        1L,
+                        "마라탕 5만원 이하로 쓰기",
+                        10,
+                        30,
+                        "/test.jpg",
+                        50000,
+                        startAt,
+                        LocalDateTime.now(),
+                        period);
+
+        assertThat(
+                        challengeStatusUtil.checkStatusInChallengeFeed(
+                                LocalDate.from(createdAt), challenge.getStartAt()))
+                .isEqualTo(StatusType.NOTHING.getName());
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
@@ -186,14 +186,6 @@ public class Challenge extends BaseTime {
         return challengeRules.stream().map(ChallengeRule::getContent).collect(toList());
     }
 
-    private boolean isNewChallenge(final LocalDate createdAt) {
-        final LocalDate currentDate = LocalDate.now();
-        final LocalDate beforeCreatedAt = LocalDate.from(createdAt.minusDays(1));
-        final LocalDate untilNewDate = LocalDate.from(createdAt.plusDays(3));
-
-        return currentDate.isAfter(beforeCreatedAt) && currentDate.isBefore(untilNewDate);
-    }
-
     private boolean isApproachingDeadline(final LocalDate startDate) {
         final LocalDate currentDate = LocalDate.now();
         final LocalDate DeadlineStart = startDate.minusDays(4);
@@ -212,14 +204,6 @@ public class Challenge extends BaseTime {
 
     public String checkStatusInChallengeDetail(final LocalDate createdAt) {
         if (isComingSoon(createdAt)) return StatusType.COMING_SOON.getName();
-        if (isApproachingDeadline(this.getDuration().getStartAt()))
-            return StatusType.APPROACHING_DEADLINE.getName();
-
-        return StatusType.NOTHING.getName();
-    }
-
-    public String checkStatusInChallengeFeed(final LocalDate createdAt) {
-        if (isNewChallenge(createdAt)) return StatusType.NEW.getName();
         if (isApproachingDeadline(this.getDuration().getStartAt()))
             return StatusType.APPROACHING_DEADLINE.getName();
 

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/StatusType.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/StatusType.java
@@ -12,7 +12,7 @@ public enum StatusType {
     NEW("new"),
     APPROACHING_DEADLINE("마감임박"),
     COMING_SOON("오픈 예정"),
-    NOTHING("해당없음");
+    NOTHING("");
 
     private String name;
 }

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeData.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeData.java
@@ -2,6 +2,7 @@ package depromeet.domain.challenge.repository;
 
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ public class ChallengeData {
     private int price;
     private List<String> keywords;
     private LocalDate startAt;
+    private LocalDateTime createdAt;
     private int period;
     private String status;
 
@@ -32,6 +34,7 @@ public class ChallengeData {
             String imgUrl,
             int price,
             LocalDate startAt,
+            LocalDateTime createdAt,
             int period) {
         this.id = id;
         this.title = title;
@@ -40,10 +43,15 @@ public class ChallengeData {
         this.imgUrl = imgUrl;
         this.price = price;
         this.startAt = startAt;
+        this.createdAt = createdAt;
         this.period = period;
     }
 
     public void setKeywordNames(List<String> keywordNames) {
         this.keywords = keywordNames;
+    }
+
+    public void setChallengeStatus(String status) {
+        this.status = status;
     }
 }

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeQueryRepository.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeQueryRepository.java
@@ -85,6 +85,7 @@ public class ChallengeQueryRepository {
                 challenge.imgUrl,
                 challenge.price,
                 challenge.duration.startAt,
+                challenge.createdAt,
                 challenge.duration.period);
     }
 

--- a/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import depromeet.domain.challenge.domain.keyword.ChallengeKeywords;
 import depromeet.domain.user.domain.User;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,32 +14,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class ChallengeTest {
-
-    /*
-    챌린지 생성일 createdAt 이후 이틀 간 New 챌린지로 표시
-    챌린지 시작일 startAt = createdAt + 7
-    */
-    @Test
-    @DisplayName("New 챌린지 - 오늘 생성된 챌린지")
-    public void isNewChallenge() {
-        int period = 5;
-        LocalDate startAt = LocalDate.now().plusDays(7);
-
-        Challenge challenge =
-                Challenge.createChallenge(
-                        "마라탕 5만원 이하로 쓰기",
-                        50000,
-                        "/test.jpg",
-                        mock(ChallengeKeywords.class),
-                        30,
-                        mock(User.class),
-                        new ArrayList<>(),
-                        mock(ChallengeCategories.class),
-                        new Duration(period, startAt, startAt.plusDays(period)));
-
-        assertThat(challenge.checkStatusInChallengeFeed(LocalDate.from(LocalDateTime.now())))
-                .isEqualTo(StatusType.NEW.getName());
-    }
 
     /*
     챌린지 모집 기간 일주일 중에서 초기 4일 동안을 오픈 예정으로 표시


### PR DESCRIPTION
## 개요
- close #245 

## 작업사항
- DTO에 상태 정보 필드 추가
- 테스트 코드 수정

## 변경로직
- Challenge에 있던 챌린지 피드 상태 정보 로직을 Util로 옮겼다.