### PR TITLE
[Feature] 챌린지 가입 시 상태값 수정

### DIFF
--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/Status.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/Status.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Status {
+    WAITING("대기중"),
     PROCEEDING("참가중"),
     SUCCESS("성공"),
     FAILURE("실패"),

--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
@@ -65,7 +65,7 @@ public class UserChallenge extends BaseTime {
                 .nickname(nickname)
                 .goalCharge(challenge.getPrice())
                 .currentCharge(0)
-                .status(Status.PROCEEDING)
+                .status(Status.WAITING)
                 .build();
     }
 


### PR DESCRIPTION
## 개요
- close #249 

## 작업사항
- 챌린지를 가입하면 WAITING(대기) 상태로 저장한다.

## 변경로직
![image](https://github.com/depromeet/jalingobi-server/assets/46569105/3dfe50fb-aaa2-4811-b747-9bbe9aa0a7f2)

