### PR TITLE
[Feature] 챌린지 가입 동시성 문제

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/JoinChallengeUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/JoinChallengeUseCase.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class JoinChallengeUseCase {
 
@@ -21,7 +21,7 @@ public class JoinChallengeUseCase {
     private final ChallengeAdaptor challengeAdaptor;
     private final UserChallengeAdaptor userChallengeAdaptor;
 
-    public void execute(
+    public synchronized void execute(
             String socialId, JoinChallengeRequest joinChallengeRequest, Long challengeId) {
         User user = userAdaptor.findUser(socialId);
         Challenge challenge = challengeAdaptor.findChallenge(challengeId);


### PR DESCRIPTION
## 개요
- close #252 

## 작업사항
- 단일 서버라서 `synchronized` 키워드를 이용해 동시성 처리
```
@Test
    public void execute() throws Exception {
        JoinChallengeRequest request =
                JoinChallengeRequest.builder().nickname("닉네임").imgUrl("/test.jpg").build();
        int threadCount = 50;
        ExecutorService executorService = Executors.newFixedThreadPool(32);
        CountDownLatch latch = new CountDownLatch(threadCount);

        for (int i = 0; i < threadCount; i++) {
            String curSocialId = socialId.get(i);
            executorService.submit(
                    () -> {
                        try {
                            joinChallengeUseCase.execute(curSocialId, request, challengeId);
                        } finally {
                            latch.countDown();
                        }
                    });
        }

        latch.await();

        assertEquals(userChallengeRepository.findAll().size(), 50);
    }
```

![image](https://github.com/depromeet/jalingobi-server/assets/46569105/7d30e5ce-1799-4e4e-b69c-23606b966f47)
