### PR TITLE
[Refactor] 참여중인 챌린지 진행상태 enum으로 전달

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/feed/dto/ParticipatedChallenge.java
+++ b/Module-API/src/main/java/depromeet/api/domain/feed/dto/ParticipatedChallenge.java
@@ -21,7 +21,7 @@ public class ParticipatedChallenge {
     @Schema(description = "챌린지 대표 이미지", example = "이미지 URL")
     private String imgUrl;
 
-    @Schema(description = "챌린지 진행 여부", example = "PROCEEDING")
+    @Schema(description = "챌린지 진행 여부 - RECRUITING, PROCEEDING 둘 중 하나의 값", example = "PROCEEDING")
     private String status;
 
     public static ParticipatedChallenge createParticipatedChallenge(Challenge challenge) {

--- a/Module-API/src/main/java/depromeet/api/domain/feed/dto/ParticipatedChallenge.java
+++ b/Module-API/src/main/java/depromeet/api/domain/feed/dto/ParticipatedChallenge.java
@@ -2,7 +2,6 @@ package depromeet.api.domain.feed.dto;
 
 
 import depromeet.domain.challenge.domain.Challenge;
-import depromeet.domain.challenge.domain.ChallengeStatusType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,7 +21,7 @@ public class ParticipatedChallenge {
     @Schema(description = "챌린지 대표 이미지", example = "이미지 URL")
     private String imgUrl;
 
-    @Schema(description = "챌린지 진행 여부")
+    @Schema(description = "챌린지 진행 여부", example = "PROCEEDING")
     private String status;
 
     public static ParticipatedChallenge createParticipatedChallenge(Challenge challenge) {
@@ -30,7 +29,7 @@ public class ParticipatedChallenge {
                 .challengeId(challenge.getId())
                 .title(challenge.getTitle())
                 .imgUrl(challenge.getImgUrl())
-                .status(ChallengeStatusType.PROCEEDING.toString())
+                .status(challenge.getStatus().toString())
                 .build();
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/feed/dto/response/GetMyChallengeListResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/feed/dto/response/GetMyChallengeListResponse.java
@@ -23,6 +23,7 @@ public class GetMyChallengeListResponse {
                 userChallengeList.stream()
                         // 날짜 오름차순 정렬
                         .sorted(Comparator.comparing(BaseTime::getCreatedAt))
+                        .filter(UserChallenge::isWaitingOrProceeding)
                         .map(UserChallenge::getChallenge)
                         .map(ParticipatedChallenge::createParticipatedChallenge)
                         .collect(Collectors.toList());

--- a/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/userchallenge/domain/UserChallenge.java
@@ -113,4 +113,8 @@ public class UserChallenge extends BaseTime {
     public void startChallenge() {
         if (status == Status.WAITING) status = Status.PROCEEDING;
     }
+
+    public boolean isWaitingOrProceeding() {
+        return (status == Status.WAITING || status == Status.PROCEEDING);
+    }
 }


### PR DESCRIPTION
## 개요
- close #264 

## 작업사항
- 기존에 챌린지 진행상태 boolean으로 전달하는것에서 enum(RECRUITING, PROCEEDING)으로 전달하는것으로 변경