### PR TITLE
[Feature] 챌린지 시작일자, 종료일자 유효성 검사

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/controller/ChallengeController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/controller/ChallengeController.java
@@ -14,6 +14,7 @@ import depromeet.api.domain.challenge.usecase.CreateChallengeUseCase;
 import depromeet.api.domain.challenge.usecase.DeleteChallengeUseCase;
 import depromeet.api.domain.challenge.usecase.JoinChallengeUseCase;
 import depromeet.api.domain.challenge.usecase.UpdateChallengeUseCase;
+import depromeet.api.domain.challenge.validator.CreateChallengeValidator;
 import depromeet.api.util.RandomNicknameGenerator;
 import depromeet.common.response.CommonResponse;
 import depromeet.common.response.Response;
@@ -39,6 +40,7 @@ public class ChallengeController {
     private final DeleteChallengeUseCase deleteChallengeUseCase;
     private final JoinChallengeUseCase joinUserChallengeUseCase;
     private final GetChallengeUseCase getChallengeUseCase;
+    private final CreateChallengeValidator createChallengeValidator;
 
     @Operation(summary = "챌린지 생성 API", description = "챌린지를 생성합니다.")
     @ApiResponses(
@@ -52,6 +54,7 @@ public class ChallengeController {
     @PostMapping
     public Response<CreateChallengeResponse> createChallenge(
             @RequestBody @Valid CreateChallengeRequest challengeRequest) {
+        createChallengeValidator.validate(challengeRequest);
         return ResponseService.getDataResponse(
                 challengeUseCase.execute(challengeRequest, getCurrentUserSocialId()));
     }

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/validator/CreateChallengeValidator.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/validator/CreateChallengeValidator.java
@@ -1,0 +1,34 @@
+package depromeet.api.domain.challenge.validator;
+
+
+import depromeet.api.domain.challenge.dto.request.CreateChallengeRequest;
+import depromeet.domain.challenge.exception.InvalidChallengeEndAtException;
+import depromeet.domain.challenge.exception.InvalidChallengeStartAtException;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CreateChallengeValidator {
+
+    private static final int RECRUIT_PERIOD = 7;
+
+    public void validate(Object target) {
+        CreateChallengeRequest createChallengeRequest = (CreateChallengeRequest) target;
+        LocalDate startAt = LocalDate.now().plusDays(RECRUIT_PERIOD);
+        int period = createChallengeRequest.getPeriod();
+
+        if (!createChallengeRequest.getStartAt().isEqual(startAt)) {
+            log.info("챌린지 시작일자 {}가 유효하지 않음", createChallengeRequest.getStartAt());
+            throw InvalidChallengeStartAtException.EXCEPTION;
+        }
+
+        if (!createChallengeRequest.getEndAt().isEqual(startAt.plusDays(period))) {
+            log.info("챌린지 종료일자 {}가 유효하지 않음", createChallengeRequest.getEndAt());
+            throw InvalidChallengeEndAtException.EXCEPTION;
+        }
+    }
+}

--- a/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeControllerTest.java
@@ -15,6 +15,7 @@ import depromeet.api.domain.challenge.dto.request.UpdateChallengeRequest;
 import depromeet.api.domain.challenge.dto.response.*;
 import depromeet.api.domain.challenge.mapper.ChallengeMapper;
 import depromeet.api.domain.challenge.usecase.*;
+import depromeet.api.domain.challenge.validator.CreateChallengeValidator;
 import depromeet.api.util.AuthenticationUtil;
 import depromeet.domain.challenge.domain.StatusType;
 import java.time.LocalDate;
@@ -59,6 +60,8 @@ public class ChallengeControllerTest {
     @MockBean JoinChallengeUseCase createUserChallengeUseCase;
 
     @MockBean GetChallengeUseCase getChallengeUseCase;
+
+    @MockBean CreateChallengeValidator createChallengeValidator;
 
     ChallengeMapper challengeMapper = new ChallengeMapper();
 

--- a/Module-Common/src/main/java/depromeet/common/exception/CustomExceptionStatus.java
+++ b/Module-Common/src/main/java/depromeet/common/exception/CustomExceptionStatus.java
@@ -49,6 +49,8 @@ public enum CustomExceptionStatus {
     CHALLENGE_NOT_BELONG_TO_USER(false, 1802, "챌린지를 생성한 유저가 아닙니다."),
     CHALLENGE_CANNOT_BE_DELETED_AFTER_START(false, 1803, "시작된 챌린지는 삭제할 수 없습니다."),
     CHALLENGE_CANNOT_BE_UPDATED_AFTER_START(false, 1804, "시작된 챌린지는 수정할 수 없습니다."),
+    INVALID_CHALLENGE_START_AT(false, 1805, "챌린지 시작일자는 생성일자 + 7입니다."),
+    INVALID_CHALLENGE_END_AT(false, 1806, "챌린지 종료일자는 시작일자 + 챌린지 기간입니다."),
 
     // feed
     FEED_NOT_FOUND(false, 1900, "요청한 날짜에 피드가 없습니다."),

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/exception/InvalidChallengeEndAtException.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/exception/InvalidChallengeEndAtException.java
@@ -1,0 +1,13 @@
+package depromeet.domain.challenge.exception;
+
+
+import depromeet.common.exception.CustomException;
+import depromeet.common.exception.CustomExceptionStatus;
+
+public class InvalidChallengeEndAtException extends CustomException {
+    public static final CustomException EXCEPTION = new InvalidChallengeEndAtException();
+
+    private InvalidChallengeEndAtException() {
+        super(CustomExceptionStatus.INVALID_CHALLENGE_END_AT);
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/exception/InvalidChallengeStartAtException.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/exception/InvalidChallengeStartAtException.java
@@ -1,0 +1,13 @@
+package depromeet.domain.challenge.exception;
+
+
+import depromeet.common.exception.CustomException;
+import depromeet.common.exception.CustomExceptionStatus;
+
+public class InvalidChallengeStartAtException extends CustomException {
+    public static final CustomException EXCEPTION = new InvalidChallengeStartAtException();
+
+    private InvalidChallengeStartAtException() {
+        super(CustomExceptionStatus.INVALID_CHALLENGE_START_AT);
+    }
+}


### PR DESCRIPTION
## 개요
- close #273 

## 작업사항
- 챌린지 생성 시 입력 값으로 들어오는 시작일자, 종료일자를 유효성 검사
