### PR TITLE
[Feature] AWS S3 이미지 처리 최적화 - 리사이징 (+Lambda)

### DIFF
--- a/Module-API/src/main/java/depromeet/api/config/s3/S3UploadPresignedUrlService.java
+++ b/Module-API/src/main/java/depromeet/api/config/s3/S3UploadPresignedUrlService.java
@@ -30,11 +30,10 @@ public class S3UploadPresignedUrlService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public ImageUrlDto execute(
-            String socialId, ImageFileExtension fileExtension, ImageUploadType type) {
+    public ImageUrlDto execute(ImageFileExtension fileExtension, ImageUploadType type) {
         String valueFileExtension = fileExtension.getUploadExtension();
         String valueType = type.getType();
-        String fileName = createFileName(socialId, valueFileExtension, valueType);
+        String fileName = createFileName(valueFileExtension, valueType);
         log.info(fileName);
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
@@ -44,8 +43,8 @@ public class S3UploadPresignedUrlService {
         return ImageUrlDto.of(url.toString(), fileName);
     }
 
-    private String createFileName(String socialId, String fileExtension, String valueType) {
-        return valueType + "/" + socialId + "/" + UUID.randomUUID() + "." + fileExtension;
+    private String createFileName(String fileExtension, String valueType) {
+        return valueType + "/original/" + UUID.randomUUID() + "." + fileExtension;
     }
 
     // 업로드용 Pre-Signed URL을 생성하기 때문에, PUT을 지정

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/JoinChallengeUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/JoinChallengeUseCase.java
@@ -30,11 +30,15 @@ public class JoinChallengeUseCase {
         challenge.validateCurrentUserCount();
         challenge.validateDuplicatedParticipation(socialId);
 
+        // custom user profile만 thumbnail 이미지로 저장
+        String thumbnailImgUrl = getThumbnailImgUrl(joinChallengeRequest.getImgUrl());
+
         userChallengeAdaptor.joinChallenge(
                 UserChallenge.createUserChallenge(
-                        user,
-                        challenge,
-                        joinChallengeRequest.getImgUrl(),
-                        joinChallengeRequest.getNickname()));
+                        user, challenge, thumbnailImgUrl, joinChallengeRequest.getNickname()));
+    }
+
+    private String getThumbnailImgUrl(String imgUrl) {
+        return imgUrl.replace("original/", "thumb/");
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/image/controller/ImageController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/controller/ImageController.java
@@ -27,11 +27,9 @@ public class ImageController {
     @Operation(summary = "presigned url을 발급받는 API")
     @PostMapping("/presigned")
     public Response<IssuePresignedUrlResponse> createPresigned(
-            @RequestBody IssuePresignedUrlRequest getPresignedUrlRequest) {
+            @RequestBody IssuePresignedUrlRequest issuePresignedUrlRequest) {
+
         return ResponseService.getDataResponse(
-                getPresignedUrlUseCase.execute(
-                        getCurrentUserSocialId(),
-                        getPresignedUrlRequest.getImageFileExtension(),
-                        getPresignedUrlRequest.getType()));
+                getPresignedUrlUseCase.execute(getCurrentUserSocialId(), issuePresignedUrlRequest));
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
@@ -22,7 +22,6 @@ public class IssuePresignedUrlUseCase {
 
         return IssuePresignedUrlResponse.from(
                 uploadPresignedUrlService.execute(
-                        socialId,
                         issuePresignedUrlRequest.getImageFileExtension(),
                         issuePresignedUrlRequest.getType()));
     }

--- a/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
@@ -2,8 +2,7 @@ package depromeet.api.domain.image.usecase;
 
 
 import depromeet.api.config.s3.S3UploadPresignedUrlService;
-import depromeet.api.domain.image.dto.ImageFileExtension;
-import depromeet.api.domain.image.dto.ImageUploadType;
+import depromeet.api.domain.image.dto.request.IssuePresignedUrlRequest;
 import depromeet.api.domain.image.dto.response.IssuePresignedUrlResponse;
 import depromeet.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +13,12 @@ public class IssuePresignedUrlUseCase {
     private final S3UploadPresignedUrlService uploadPresignedUrlService;
 
     public IssuePresignedUrlResponse execute(
-            String socialId, ImageFileExtension imageFileExtension, ImageUploadType type) {
+            String socialId, IssuePresignedUrlRequest issuePresignedUrlRequest) {
 
         return IssuePresignedUrlResponse.from(
-                uploadPresignedUrlService.execute(socialId, imageFileExtension, type));
+                uploadPresignedUrlService.execute(
+                        socialId,
+                        issuePresignedUrlRequest.getImageFileExtension(),
+                        issuePresignedUrlRequest.getType()));
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
@@ -5,15 +5,20 @@ import depromeet.api.config.s3.S3UploadPresignedUrlService;
 import depromeet.api.domain.image.dto.request.IssuePresignedUrlRequest;
 import depromeet.api.domain.image.dto.response.IssuePresignedUrlResponse;
 import depromeet.common.annotation.UseCase;
+import depromeet.domain.user.adaptor.UserAdaptor;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
 public class IssuePresignedUrlUseCase {
+
+    private final UserAdaptor userAdaptor;
     private final S3UploadPresignedUrlService uploadPresignedUrlService;
 
     public IssuePresignedUrlResponse execute(
             String socialId, IssuePresignedUrlRequest issuePresignedUrlRequest) {
+
+        userAdaptor.doesUserExist(socialId);
 
         return IssuePresignedUrlResponse.from(
                 uploadPresignedUrlService.execute(

--- a/Module-API/src/test/java/depromeet/api/domain/image/controller/ImageControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/image/controller/ImageControllerTest.java
@@ -86,11 +86,7 @@ public class ImageControllerTest {
 
         String socialId = "socialId";
         given(AuthenticationUtil.getCurrentUserSocialId()).willReturn(socialId);
-        given(
-                        issuePresignedUrlUseCase.execute(
-                                anyString(),
-                                any(ImageFileExtension.class),
-                                any(ImageUploadType.class)))
+        given(issuePresignedUrlUseCase.execute(anyString(), any(IssuePresignedUrlRequest.class)))
                 .willReturn(issuePresignedUrlResponse);
 
         mockMvc.perform(requestBuilder)

--- a/Module-Domain/src/main/java/depromeet/domain/user/adaptor/UserAdaptor.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/adaptor/UserAdaptor.java
@@ -33,4 +33,12 @@ public class UserAdaptor {
                 .findBySocialId(socialId)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
     }
+
+    public void doesUserExist(String socialId) {
+        boolean isExist = userRepository.existsBySocialId(socialId);
+
+        if (!isExist) {
+            throw UserNotFoundException.EXCEPTION;
+        }
+    }
 }

--- a/Module-Domain/src/main/java/depromeet/domain/user/repository/UserRepository.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialId(String socialId);
 
     Optional<User> findByProfileEmail(String email);
+
+    boolean existsBySocialId(String socialId);
 }


### PR DESCRIPTION
## 개요
- close #97

(놀랍다 이슈 200 후반대인 세상에서 등장한 90번 대 (◔◡◔) 귀하다 귀해)

## 작업사항
- 람다 설정하고 트리거는 챌린지 가입 시 커스텀 유저 프로필에 대해서만 썸네일 생성하도록 해뒀습니당
![image](https://github.com/depromeet/jalingobi-server/assets/97580782/f87b3a61-78b6-42b3-a679-3ed01a0649fa)

<img src="https://github.com/depromeet/jalingobi-server/assets/97580782/ac5f403e-8fc6-444a-95d0-ca1b2d60408a" width=400>

## 변경로직
- 이미지 저장 경로(S3 key) 변경
- 커스텀 유저 프로필은 썸네일 이미지로 저장

### 구현 과정
- [[AWS S3+Lambda] 이미지 처리 2탄: Image Resizing으로 썸네일 이미지 만들기](https://hello-judy-world.tistory.com/220)