### PR TITLE
[Refactor] 예외처리 - 종료된 챌린지에 대한 기록 생성, 수정, 삭제

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/usecase/IssuePresignedUrlUseCase.java
@@ -18,7 +18,7 @@ public class IssuePresignedUrlUseCase {
     public IssuePresignedUrlResponse execute(
             String socialId, IssuePresignedUrlRequest issuePresignedUrlRequest) {
 
-        userAdaptor.doesUserExist(socialId);
+        userAdaptor.isExistUser(socialId);
 
         return IssuePresignedUrlResponse.from(
                 uploadPresignedUrlService.execute(

--- a/Module-API/src/main/java/depromeet/api/domain/record/exception/InvalidChallengeStatusException.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/exception/InvalidChallengeStatusException.java
@@ -1,0 +1,14 @@
+package depromeet.api.domain.record.exception;
+
+
+import depromeet.common.exception.CustomException;
+import depromeet.common.exception.CustomExceptionStatus;
+
+public class InvalidChallengeStatusException extends CustomException {
+
+    public static final CustomException EXCEPTION = new InvalidChallengeStatusException();
+
+    private InvalidChallengeStatusException() {
+        super(CustomExceptionStatus.CHALLENGE_NOT_IN_PROCEEDING);
+    }
+}

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/CreateRecordUseCase.java
@@ -34,6 +34,7 @@ public class CreateRecordUseCase {
 
         User currentUser = userAdaptor.findUser(socialId);
         Challenge challenge = challengeAdaptor.findChallenge(challengeId);
+        recordValidator.validateProceedingChallenge(challenge);
         recordValidator.validateUnparticipatedChallenge(socialId, challenge);
 
         UserChallenge userChallenge =

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/DeleteRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/DeleteRecordUseCase.java
@@ -20,6 +20,7 @@ public class DeleteRecordUseCase {
     public void execute(Long recordId, String socialId) {
 
         Record record = recordAdaptor.findRecord(recordId);
+        recordValidator.validateProceedingChallenge(record.getChallenge());
         recordValidator.validateCorrectUserRecord(record, socialId);
 
         UserChallenge userChallenge = record.getUserChallenge();

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
@@ -27,6 +27,7 @@ public class UpdateRecordUseCase {
     public void execute(Long recordId, String socialId, UpdateRecordRequest updateRecordRequest) {
         Record record = recordAdaptor.findRecord(recordId);
 
+        recordValidator.validateProceedingChallenge(record.getChallenge());
         recordValidator.validateCorrectUserRecord(record, socialId);
 
         Optional<String> currentImgUrl = Optional.ofNullable(record.getImgUrl());

--- a/Module-API/src/main/java/depromeet/api/domain/record/validator/RecordValidator.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/validator/RecordValidator.java
@@ -1,6 +1,7 @@
 package depromeet.api.domain.record.validator;
 
 
+import depromeet.api.domain.record.exception.InvalidChallengeStatusException;
 import depromeet.api.domain.record.exception.InvalidUserChallengeException;
 import depromeet.api.domain.record.exception.InvalidUserRecordException;
 import depromeet.domain.challenge.domain.Challenge;
@@ -20,6 +21,12 @@ public class RecordValidator {
     public void validateCorrectUserRecord(Record record, String socialId) {
         if (!record.getUser().isSameUser(socialId)) {
             throw InvalidUserRecordException.EXCEPTION;
+        }
+    }
+
+    public void validateProceedingChallenge(Challenge challenge) {
+        if (!challenge.isProceeding()) {
+            throw InvalidChallengeStatusException.EXCEPTION;
         }
     }
 }

--- a/Module-Common/src/main/java/depromeet/common/exception/CustomExceptionStatus.java
+++ b/Module-Common/src/main/java/depromeet/common/exception/CustomExceptionStatus.java
@@ -52,6 +52,7 @@ public enum CustomExceptionStatus {
     CHALLENGE_CANNOT_BE_UPDATED_AFTER_START(false, 1804, "시작된 챌린지는 수정할 수 없습니다."),
     INVALID_CHALLENGE_START_AT(false, 1805, "챌린지 시작일자는 생성일자 + 7입니다."),
     INVALID_CHALLENGE_END_AT(false, 1806, "챌린지 종료일자는 시작일자 + 챌린지 기간입니다."),
+    CHALLENGE_NOT_IN_PROCEEDING(false, 1807, "진행 중인 챌린지가 아닙니다."),
 
     // feed
     FEED_NOT_FOUND(false, 1900, "요청한 날짜에 피드가 없습니다."),

--- a/Module-Domain/src/main/java/depromeet/domain/user/adaptor/UserAdaptor.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/adaptor/UserAdaptor.java
@@ -34,7 +34,7 @@ public class UserAdaptor {
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
     }
 
-    public void doesUserExist(String socialId) {
+    public void isExistUser(String socialId) {
         boolean isExist = userRepository.existsBySocialId(socialId);
 
         if (!isExist) {


### PR DESCRIPTION
## 개요
- close #290 

## 작업사항
- 챌린지 기록 생성, 수정, 삭제는 종료되지 않은 챌린지에 대해서만 가능 (즉, 진행중일 때만)

![image](https://github.com/depromeet/jalingobi-server/assets/97580782/a6eb6a62-803e-4173-9fb6-e55e21cfb66b)

![image](https://github.com/depromeet/jalingobi-server/assets/97580782/e9a35fcb-c19b-4b8a-8c87-ba3e49ac4ad9)

![image](https://github.com/depromeet/jalingobi-server/assets/97580782/e47adb98-15be-40b0-9e59-bb54714b1a2e)
