### PR TITLE
[Refactor] 챌린지 기록 삭제 시 S3 이미지 삭제하는 로직 추가

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/DeleteRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/DeleteRecordUseCase.java
@@ -1,21 +1,27 @@
 package depromeet.api.domain.record.usecase;
 
 
+import depromeet.api.config.s3.S3UploadPresignedUrlService;
 import depromeet.api.domain.record.validator.RecordValidator;
 import depromeet.common.annotation.UseCase;
 import depromeet.domain.record.adaptor.RecordAdaptor;
 import depromeet.domain.record.domain.Record;
 import depromeet.domain.userchallenge.domain.UserChallenge;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @Transactional
 @RequiredArgsConstructor
 public class DeleteRecordUseCase {
+    @Value("${image.prefix}")
+    private String prefix;
 
     private final RecordAdaptor recordAdaptor;
     private final RecordValidator recordValidator;
+    private final S3UploadPresignedUrlService uploadPresignedUrlService;
 
     public void execute(Long recordId, String socialId) {
 
@@ -23,9 +29,25 @@ public class DeleteRecordUseCase {
         recordValidator.validateCorrectUserRecord(record, socialId);
         recordValidator.validateProceedingChallenge(record.getChallenge());
 
+        removeS3OldImage(record);
+
         UserChallenge userChallenge = record.getUserChallenge();
         userChallenge.removeCharge(record.getPrice());
 
         recordAdaptor.deleteRecord(recordId);
+    }
+
+    private String getKey(String imgUrl) {
+        String[] splitUrl = imgUrl.split(prefix);
+        return splitUrl[1];
+    }
+
+    private void removeS3OldImage(Record record) {
+        Optional<String> currentImgUrl = Optional.ofNullable(record.getImgUrl());
+        if (currentImgUrl.isPresent()) {
+            String imgUrl = currentImgUrl.get();
+            String key = getKey(imgUrl);
+            uploadPresignedUrlService.deleteImage(key);
+        }
     }
 }

--- a/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/record/usecase/UpdateRecordUseCase.java
@@ -30,15 +30,9 @@ public class UpdateRecordUseCase {
         recordValidator.validateCorrectUserRecord(record, socialId);
         recordValidator.validateProceedingChallenge(record.getChallenge());
 
-        Optional<String> currentImgUrl = Optional.ofNullable(record.getImgUrl());
-        if (currentImgUrl.isPresent()) {
-            String imgUrl = currentImgUrl.get();
-            String key = getKey(imgUrl);
-            uploadPresignedUrlService.deleteImage(key);
-        }
-        UserChallenge userChallenge = record.getUserChallenge();
-        userChallenge.removeCharge(record.getPrice());
-        userChallenge.addCharge(updateRecordRequest.getPrice());
+        removeS3OldImage(record);
+
+        updateCharge(record, updateRecordRequest);
 
         record.updateRecord(
                 updateRecordRequest.getPrice(),
@@ -51,5 +45,20 @@ public class UpdateRecordUseCase {
     private String getKey(String imgUrl) {
         String[] splitUrl = imgUrl.split(prefix);
         return splitUrl[1];
+    }
+
+    private void removeS3OldImage(Record record) {
+        Optional<String> currentImgUrl = Optional.ofNullable(record.getImgUrl());
+        if (currentImgUrl.isPresent()) {
+            String imgUrl = currentImgUrl.get();
+            String key = getKey(imgUrl);
+            uploadPresignedUrlService.deleteImage(key);
+        }
+    }
+
+    private void updateCharge(Record record, UpdateRecordRequest updateRecordRequest) {
+        UserChallenge userChallenge = record.getUserChallenge();
+        userChallenge.removeCharge(record.getPrice());
+        userChallenge.addCharge(updateRecordRequest.getPrice());
     }
 }


### PR DESCRIPTION
## 개요
- close #306 

## 작업사항
- 챌린지 기록 삭제 시 S3에 저장된 기존 이미지 삭제
- S3에 이미지 삭제하는 코드 private 메서드로 분리하기

## 로직 설명

- 이미지 저장 시 url은 s3 경로와 일치하게 보내주어야 동작합니다!

ex.

- 챌린지 기록할 때

![image](https://github.com/depromeet/jalingobi-server/assets/97580782/1c41138c-9bf7-4a88-a15e-f4da9be9cad1)

- 수정할 때

![image](https://github.com/depromeet/jalingobi-server/assets/97580782/bb45c00e-7def-49d3-8c5f-97d1c54cf30f)
