### PR TITLE
[Feature] 챌린지 생성 시 기본 이미지 설정

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/GetChallengeResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/dto/response/GetChallengeResponse.java
@@ -53,7 +53,7 @@ public class GetChallengeResponse {
                 .category(challenge.getChallengeCategories().getCategoryNames().get(0))
                 .title(challenge.getTitle())
                 .price(challenge.getPrice())
-                .challengeImgUrl(challenge.getImgUrl())
+                .challengeImgUrl(challenge.getImage().getDefaultUrl())
                 .keywords(challenge.getChallengeKeywords().getKeywordNames())
                 .headCount(
                         new HeadCountResponse(

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/mapper/ChallengeMapper.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/mapper/ChallengeMapper.java
@@ -24,7 +24,6 @@ public class ChallengeMapper {
         return Challenge.createChallenge(
                 createChallengeRequest.getTitle(),
                 createChallengeRequest.getPrice(),
-                createChallengeRequest.getImageUrl(),
                 new ChallengeKeywords(),
                 createChallengeRequest.getAvailableCount(),
                 user,

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/CreateChallengeUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/CreateChallengeUseCase.java
@@ -62,8 +62,11 @@ public class CreateChallengeUseCase {
 
         Challenge challenge = challengeMapper.toEntity(request, user);
 
-        if (request.getImageUrl() != null) challenge.addImage(request.getImageUrl());
-        else challenge.addDefaultImage(request.getCategory().get(0));
+        String defaultUrl = "";
+        if (request.getImageUrl() != null) defaultUrl = request.getImageUrl();
+        else defaultUrl = challenge.getDefaultImage(request.getCategory().get(0));
+
+        challenge.addImage(defaultUrl, request.getCategory().get(0));
 
         challenge.addCategories(categories);
         challenge.addRules(challengeRuleMapper.toEntities(request.getChallengeRule()));

--- a/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/CreateChallengeUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/challenge/usecase/CreateChallengeUseCase.java
@@ -62,6 +62,9 @@ public class CreateChallengeUseCase {
 
         Challenge challenge = challengeMapper.toEntity(request, user);
 
+        if (request.getImageUrl() != null) challenge.addImage(request.getImageUrl());
+        else challenge.addDefaultImage(request.getCategory().get(0));
+
         challenge.addCategories(categories);
         challenge.addRules(challengeRuleMapper.toEntities(request.getChallengeRule()));
         challenge.addKeywords(keywords);

--- a/Module-API/src/main/java/depromeet/api/domain/feed/dto/MyFeed.java
+++ b/Module-API/src/main/java/depromeet/api/domain/feed/dto/MyFeed.java
@@ -42,7 +42,7 @@ public class MyFeed {
         private String title;
 
         public ChallengeInfo(Challenge challenge) {
-            this.imgUrl = challenge.getImgUrl();
+            this.imgUrl = challenge.getImage().getThumbUrl();
             this.title = challenge.getTitle();
         }
     }

--- a/Module-API/src/main/java/depromeet/api/domain/feed/dto/MyFeed.java
+++ b/Module-API/src/main/java/depromeet/api/domain/feed/dto/MyFeed.java
@@ -47,7 +47,7 @@ public class MyFeed {
 
         public ChallengeInfo(Challenge challenge) {
             this.id = challenge.getId();
-            this.imgUrl = challenge.getImgUrl();
+            this.imgUrl = challenge.getImage().getThumbUrl();
             this.title = challenge.getTitle();
         }
     }

--- a/Module-API/src/main/java/depromeet/api/domain/feed/dto/ParticipatedChallenge.java
+++ b/Module-API/src/main/java/depromeet/api/domain/feed/dto/ParticipatedChallenge.java
@@ -28,7 +28,7 @@ public class ParticipatedChallenge {
         return ParticipatedChallenge.builder()
                 .challengeId(challenge.getId())
                 .title(challenge.getTitle())
-                .imgUrl(challenge.getImgUrl())
+                .imgUrl(challenge.getImage().getThumbUrl())
                 .status(challenge.getStatus().toString())
                 .build();
     }

--- a/Module-API/src/main/java/depromeet/api/domain/mypage/dto/MyPageUserChallenge.java
+++ b/Module-API/src/main/java/depromeet/api/domain/mypage/dto/MyPageUserChallenge.java
@@ -56,7 +56,7 @@ public class MyPageUserChallenge {
         return MyPageUserChallenge.builder()
                 .challengeId(challenge.getId())
                 .title(challenge.getTitle())
-                .imgUrl(challenge.getImgUrl())
+                .imgUrl(challenge.getImage().getThumbUrl())
                 .active(challenge.isProceeding())
                 .duration(dateInfo)
                 .availableCount(challenge.getAvailableCount())

--- a/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeFeedControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/challenge/controller/ChallengeFeedControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import depromeet.api.config.security.filter.JwtRequestFilter;
 import depromeet.api.domain.challenge.usecase.GetChallengeInfiniteScrollFeedUseCase;
 import depromeet.domain.challenge.domain.ChallengeSlice;
+import depromeet.domain.challenge.domain.Image;
 import depromeet.domain.challenge.repository.ChallengeData;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -55,7 +56,7 @@ public class ChallengeFeedControllerTest {
                         "마라탕 10만원 이하로 쓰기",
                         2,
                         10,
-                        "/test.jpg",
+                        new Image("/test.png", "/thumb/test.png"),
                         100000,
                         LocalDate.now(),
                         LocalDateTime.now().minusDays(7),

--- a/Module-API/src/test/java/depromeet/api/util/ChallengeStatusUtilTest.java
+++ b/Module-API/src/test/java/depromeet/api/util/ChallengeStatusUtilTest.java
@@ -2,6 +2,7 @@ package depromeet.api.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import depromeet.domain.challenge.domain.Image;
 import depromeet.domain.challenge.domain.StatusType;
 import depromeet.domain.challenge.repository.ChallengeData;
 import java.time.LocalDate;
@@ -32,7 +33,7 @@ public class ChallengeStatusUtilTest {
                         "마라탕 5만원 이하로 쓰기",
                         10,
                         30,
-                        "/test.jpg",
+                        new Image("/test.png", "/thumb/test.png"),
                         50000,
                         startAt,
                         LocalDateTime.now(),
@@ -61,7 +62,7 @@ public class ChallengeStatusUtilTest {
                         "마라탕 5만원 이하로 쓰기",
                         10,
                         30,
-                        "/test.jpg",
+                        new Image("/test.png", "/thumb/test.png"),
                         50000,
                         startAt,
                         LocalDateTime.now(),
@@ -86,7 +87,7 @@ public class ChallengeStatusUtilTest {
                         "마라탕 5만원 이하로 쓰기",
                         10,
                         30,
-                        "/test.jpg",
+                        new Image("/test.png", "/thumb/test.png"),
                         50000,
                         startAt,
                         LocalDateTime.now(),

--- a/Module-Domain/build.gradle
+++ b/Module-Domain/build.gradle
@@ -4,6 +4,7 @@ jar { enabled = true }
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.mysql:mysql-connector-j'
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.5.0'
 
     // Querydsl
     implementation "com.querydsl:querydsl-core" // querydsl

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/CategoryType.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/CategoryType.java
@@ -7,10 +7,19 @@ import lombok.Getter;
 
 @Getter
 public enum CategoryType {
-    FOOD,
-    HOBBY_LEISURE,
-    FASHION_BEAUTY,
-    TRANSPORTATION_AUTOMOBILE;
+    FOOD(DefaultImageProperties.food, ThumbImageProperties.food),
+    HOBBY_LEISURE(DefaultImageProperties.hobby, ThumbImageProperties.hobby),
+    FASHION_BEAUTY(DefaultImageProperties.fashionBeauty, ThumbImageProperties.fashionBeauty),
+    TRANSPORTATION_AUTOMOBILE(
+            DefaultImageProperties.transportation, ThumbImageProperties.transportation);
+
+    private final String defaultUrl;
+    private final String thumbUrl;
+
+    CategoryType(String defaultUrl, String thumbUrl) {
+        this.defaultUrl = defaultUrl;
+        this.thumbUrl = thumbUrl;
+    }
 
     public static CategoryType of(String source) {
         return Arrays.stream(CategoryType.values())

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Challenge.java
@@ -71,7 +71,6 @@ public class Challenge extends BaseTime {
     public static Challenge createChallenge(
             String title,
             int price,
-            String imgUrl,
             ChallengeKeywords challengeKeywords,
             int availableCount,
             User user,
@@ -81,7 +80,6 @@ public class Challenge extends BaseTime {
         return Challenge.builder()
                 .title(title)
                 .price(price)
-                .imgUrl(imgUrl)
                 .challengeKeywords(challengeKeywords)
                 .availableCount(availableCount)
                 .status(ChallengeStatusType.RECRUITING)
@@ -104,6 +102,14 @@ public class Challenge extends BaseTime {
 
     public void addKeywords(List<Keyword> keywords) {
         challengeKeywords.addAll(this, keywords);
+    }
+
+    public void addDefaultImage(String category) {
+        this.imgUrl = CategoryType.valueOf(category).getDefaultUrl();
+    }
+
+    public void addImage(String imgUrl) {
+        this.imgUrl = imgUrl;
     }
 
     public boolean isParticipateChallengeUser(String socialId) {

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/DefaultImageProperties.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/DefaultImageProperties.java
@@ -1,0 +1,46 @@
+package depromeet.domain.challenge.domain;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultImageProperties {
+
+    public static String food;
+    public static String coffee;
+    public static String delivery;
+    public static String hobby;
+    public static String fashionBeauty;
+    public static String transportation;
+
+    @Value("${image.default.category.food}")
+    public void setFood(String food) {
+        this.food = food;
+    }
+
+    @Value("${image.default.category.coffee}")
+    public void setCoffee(String coffee) {
+        this.coffee = coffee;
+    }
+
+    @Value("${image.default.category.delivery}")
+    public void setDelivery(String delivery) {
+        this.delivery = delivery;
+    }
+
+    @Value("${image.default.category.hobby}")
+    public void setHobby(String hobby) {
+        this.hobby = hobby;
+    }
+
+    @Value("${image.default.category.fashion-beauty}")
+    public void setFashionBeauty(String fashionBeauty) {
+        this.fashionBeauty = fashionBeauty;
+    }
+
+    @Value("${image.default.category.transportation}")
+    public void setTransportation(String transportation) {
+        this.transportation = transportation;
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/FoodDetailType.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/FoodDetailType.java
@@ -1,0 +1,18 @@
+package depromeet.domain.challenge.domain;
+
+
+import lombok.Getter;
+
+@Getter
+public enum FoodDetailType {
+    COFFEE(DefaultImageProperties.coffee, ThumbImageProperties.coffee),
+    DELIVERY(DefaultImageProperties.delivery, ThumbImageProperties.delivery);
+
+    private final String defaultUrl;
+    private final String thumbUrl;
+
+    FoodDetailType(String defaultUrl, String thumbUrl) {
+        this.defaultUrl = defaultUrl;
+        this.thumbUrl = thumbUrl;
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Image.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/Image.java
@@ -1,0 +1,16 @@
+package depromeet.domain.challenge.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Image {
+
+    private String defaultUrl;
+
+    private String thumbUrl;
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/domain/ThumbImageProperties.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/domain/ThumbImageProperties.java
@@ -1,0 +1,46 @@
+package depromeet.domain.challenge.domain;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThumbImageProperties {
+
+    public static String food;
+    public static String coffee;
+    public static String delivery;
+    public static String hobby;
+    public static String fashionBeauty;
+    public static String transportation;
+
+    @Value("${image.thumb.category.food}")
+    public void setFood(String food) {
+        this.food = food;
+    }
+
+    @Value("${image.thumb.category.coffee}")
+    public void setCoffee(String coffee) {
+        this.coffee = coffee;
+    }
+
+    @Value("${image.thumb.category.delivery}")
+    public void setDelivery(String delivery) {
+        this.delivery = delivery;
+    }
+
+    @Value("${image.thumb.category.hobby}")
+    public void setHobby(String hobby) {
+        this.hobby = hobby;
+    }
+
+    @Value("${image.thumb.category.fashion-beauty}")
+    public void setFashionBeauty(String fashionBeauty) {
+        this.fashionBeauty = fashionBeauty;
+    }
+
+    @Value("${image.thumb.category.transportation}")
+    public void setTransportation(String transportation) {
+        this.transportation = transportation;
+    }
+}

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeData.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeData.java
@@ -1,6 +1,7 @@
 package depromeet.domain.challenge.repository;
 
 
+import depromeet.domain.challenge.domain.Image;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,7 +19,7 @@ public class ChallengeData {
     private String title;
     private int currentPeopleCount;
     private int availablePeopleCount;
-    private String imgUrl;
+    private String image;
     private int price;
     private List<String> keywords;
     private LocalDate startAt;
@@ -31,7 +32,7 @@ public class ChallengeData {
             String title,
             int currentPeopleCount,
             int availablePeopleCount,
-            String imgUrl,
+            Image image,
             int price,
             LocalDate startAt,
             LocalDateTime createdAt,
@@ -40,7 +41,7 @@ public class ChallengeData {
         this.title = title;
         this.currentPeopleCount = currentPeopleCount;
         this.availablePeopleCount = availablePeopleCount;
-        this.imgUrl = imgUrl;
+        this.image = image.getThumbUrl();
         this.price = price;
         this.startAt = startAt;
         this.createdAt = createdAt;

--- a/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeQueryRepository.java
+++ b/Module-Domain/src/main/java/depromeet/domain/challenge/repository/ChallengeQueryRepository.java
@@ -82,7 +82,7 @@ public class ChallengeQueryRepository {
                 challenge.title,
                 challenge.userChallenges.size(),
                 challenge.availableCount,
-                challenge.imgUrl,
+                challenge.image,
                 challenge.price,
                 challenge.duration.startAt,
                 challenge.createdAt,

--- a/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/challenge/domain/ChallengeTest.java
@@ -29,7 +29,6 @@ public class ChallengeTest {
                 Challenge.createChallenge(
                         "마라탕 5만원 이하로 쓰기",
                         50000,
-                        "/test.jpg",
                         mock(ChallengeKeywords.class),
                         30,
                         mock(User.class),
@@ -56,7 +55,6 @@ public class ChallengeTest {
                 Challenge.createChallenge(
                         "마라탕 5만원 이하로 쓰기",
                         50000,
-                        "/test.jpg",
                         mock(ChallengeKeywords.class),
                         30,
                         mock(User.class),
@@ -79,7 +77,6 @@ public class ChallengeTest {
                 Challenge.createChallenge(
                         "마라탕 5만원 이하로 쓰기",
                         50000,
-                        "/test.jpg",
                         mock(ChallengeKeywords.class),
                         30,
                         mock(User.class),

--- a/Module-Domain/src/test/java/depromeet/domain/record/adaptor/RecordAdaptorTest.java
+++ b/Module-Domain/src/test/java/depromeet/domain/record/adaptor/RecordAdaptorTest.java
@@ -8,6 +8,7 @@ import depromeet.domain.category.domain.Category;
 import depromeet.domain.challenge.domain.Challenge;
 import depromeet.domain.challenge.domain.ChallengeCategories;
 import depromeet.domain.challenge.domain.Duration;
+import depromeet.domain.challenge.domain.Image;
 import depromeet.domain.challenge.domain.keyword.ChallengeKeywords;
 import depromeet.domain.keyword.domain.Keyword;
 import depromeet.domain.record.domain.Evaluation;
@@ -62,7 +63,7 @@ class RecordAdaptorTest {
                         .challengeCategories(challengeCategories)
                         .title("식비 줄이기 챌린지")
                         .price(5000)
-                        .imgUrl("")
+                        .image(new Image("/test.png", "/thumb/test.png"))
                         .challengeKeywords(challengeKeywords)
                         .availableCount(5)
                         .createdBy(user)


### PR DESCRIPTION
## 개요
- close #349 

## 작업사항
- 카테고리에 따른 기본 썸네일 이미지 설정
- 업로드한 이미지가 없다면, 챌린지 상세 조회에서 보여주는 이미지 또한 카테고리를 바탕으로 기본 이미지 설정
- 커피/배달이 제목에 포함되어 있다면 해당 이미지로 설정

## 변경로직
필드명 및 타입 변경
![image](https://github.com/depromeet/jalingobi-server/assets/46569105/c435ad6e-1954-4d57-b5d0-3ee919b32c5d)