### PR TITLE
[Refactor] presigned url 발급 응답 값에 key 값 대신 image url

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/image/dto/response/IssuePresignedUrlResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/dto/response/IssuePresignedUrlResponse.java
@@ -15,7 +15,8 @@ public class IssuePresignedUrlResponse {
 
     @Schema(
             description = "s3에 저장될 경로",
-            example = "https://jalingobi-bucket-test.s3.ap-northeast-2.amazonaws.com/record/original/7e3e0dca-2491-4764-80f2-593166d9712b.png")
+            example =
+                    "https://jalingobi-bucket-test.s3.ap-northeast-2.amazonaws.com/record/original/7e3e0dca-2491-4764-80f2-593166d9712b.png")
     private final String imgUrl;
 
     public static IssuePresignedUrlResponse from(ImageUrlDto urlDto) {

--- a/Module-API/src/main/java/depromeet/api/domain/image/dto/response/IssuePresignedUrlResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/dto/response/IssuePresignedUrlResponse.java
@@ -2,6 +2,7 @@ package depromeet.api.domain.image.dto.response;
 
 
 import depromeet.api.domain.image.dto.ImageUrlDto;
+import depromeet.api.util.ImageUrlUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,13 +15,15 @@ public class IssuePresignedUrlResponse {
 
     @Schema(
             description = "s3에 저장될 경로",
-            example = "record/2817216430/7e3e0dca-2491-4764-80f2-593166d9712b.png")
-    private final String key;
+            example = "https://jalingobi-bucket-test.s3.ap-northeast-2.amazonaws.com/record/original/7e3e0dca-2491-4764-80f2-593166d9712b.png")
+    private final String imgUrl;
 
     public static IssuePresignedUrlResponse from(ImageUrlDto urlDto) {
+        String imgUrl = ImageUrlUtil.prefix + urlDto.getKey();
+
         return IssuePresignedUrlResponse.builder()
                 .presignedUrl(urlDto.getPresignedUrl())
-                .key(urlDto.getKey())
+                .imgUrl(imgUrl)
                 .build();
     }
 }

--- a/Module-API/src/main/java/depromeet/api/util/ImageUrlUtil.java
+++ b/Module-API/src/main/java/depromeet/api/util/ImageUrlUtil.java
@@ -1,0 +1,15 @@
+package depromeet.api.util;
+
+
+import depromeet.common.annotation.Util;
+import org.springframework.beans.factory.annotation.Value;
+
+@Util
+public class ImageUrlUtil {
+    public static String prefix;
+
+    @Value("${image.prefix}")
+    public void setPrefix(String value) {
+        prefix = value;
+    }
+}

--- a/Module-API/src/test/java/depromeet/api/domain/image/controller/ImageControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/image/controller/ImageControllerTest.java
@@ -74,7 +74,7 @@ public class ImageControllerTest {
         IssuePresignedUrlResponse issuePresignedUrlResponse =
                 IssuePresignedUrlResponse.builder()
                         .presignedUrl("dasfgsdfadagdsafgdsagsd")
-                        .key("profile/userid/dahjfhlfa.jpg")
+                        .imgUrl("profile/userid/dahjfhlfa.jpg")
                         .build();
 
         MockHttpServletRequestBuilder requestBuilder =
@@ -95,6 +95,6 @@ public class ImageControllerTest {
                         status().isOk(),
                         jsonPath("$.result.presignedUrl")
                                 .value(issuePresignedUrlResponse.getPresignedUrl()),
-                        jsonPath("$.result.key").value(issuePresignedUrlResponse.getKey()));
+                        jsonPath("$.result.imgUrl").value(issuePresignedUrlResponse.getImgUrl()));
     }
 }


### PR DESCRIPTION
## 개요
- close #372

## 작업사항
-  버킷 key 값이 아닌 이미지 url로 응답할 수 있도록 수정

![image](https://github.com/depromeet/jalingobi-server/assets/97580782/6704db47-1b29-4ef4-a7bc-820f46de2ca1)

prefix 동적 할당은 util 함수로