### PR TITLE
[Bug] ImageUrlUtil 이름 중복

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/image/dto/response/IssuePresignedUrlResponse.java
+++ b/Module-API/src/main/java/depromeet/api/domain/image/dto/response/IssuePresignedUrlResponse.java
@@ -2,7 +2,7 @@ package depromeet.api.domain.image.dto.response;
 
 
 import depromeet.api.domain.image.dto.ImageUrlDto;
-import depromeet.api.util.ImageUrlUtil;
+import depromeet.api.util.ApiImageUrlUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +20,7 @@ public class IssuePresignedUrlResponse {
     private final String imgUrl;
 
     public static IssuePresignedUrlResponse from(ImageUrlDto urlDto) {
-        String imgUrl = ImageUrlUtil.prefix + urlDto.getKey();
+        String imgUrl = ApiImageUrlUtil.prefix + urlDto.getKey();
 
         return IssuePresignedUrlResponse.builder()
                 .presignedUrl(urlDto.getPresignedUrl())

--- a/Module-API/src/main/java/depromeet/api/util/ApiImageUrlUtil.java
+++ b/Module-API/src/main/java/depromeet/api/util/ApiImageUrlUtil.java
@@ -5,7 +5,7 @@ import depromeet.common.annotation.Util;
 import org.springframework.beans.factory.annotation.Value;
 
 @Util
-public class ImageUrlUtil {
+public class ApiImageUrlUtil {
     public static String prefix;
 
     @Value("${image.prefix}")

--- a/Module-Domain/src/main/java/depromeet/domain/user/domain/Profile.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/domain/Profile.java
@@ -1,7 +1,7 @@
 package depromeet.domain.user.domain;
 
 
-import depromeet.domain.user.util.ImageUrlUtil;
+import depromeet.domain.user.util.DomainImageUrlUtil;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.*;
@@ -23,7 +23,7 @@ public class Profile {
 
     /** 생성 메서드 */
     public static Profile createProfile(String name, String email) {
-        String imgUrl = ImageUrlUtil.defaultImgUrl;
+        String imgUrl = DomainImageUrlUtil.defaultImgUrl;
         return Profile.builder().nickname(name).email(email).imgUrl(imgUrl).build();
     }
 

--- a/Module-Domain/src/main/java/depromeet/domain/user/util/DomainImageUrlUtil.java
+++ b/Module-Domain/src/main/java/depromeet/domain/user/util/DomainImageUrlUtil.java
@@ -5,7 +5,7 @@ import depromeet.common.annotation.Util;
 import org.springframework.beans.factory.annotation.Value;
 
 @Util
-public class ImageUrlUtil {
+public class DomainImageUrlUtil {
     public static String defaultImgUrl;
 
     @Value("${image.default.profile}")


### PR DESCRIPTION
## 개요
- close #375 

## 작업사항
- 현재 ImageUrlUtil 이름이 중복되고 있어서 bean등록시 충돌. 현재는 prefix로 모듈명 추가함