### PR TITLE
[Hotfix] 댓글 생성, 삭제 에러 해결

### DIFF
--- a/Module-API/src/main/java/depromeet/api/domain/comment/controller/CommentController.java
+++ b/Module-API/src/main/java/depromeet/api/domain/comment/controller/CommentController.java
@@ -32,7 +32,8 @@ public class CommentController {
     @Operation(summary = "댓글 생성 API", description = "댓글을 생성합니다.")
     public Response<CreateCommentResponse> createComment(
             @PathVariable long recordId, @Valid @RequestBody CreateCommentRequest request) {
-        return ResponseService.getDataResponse(createCommentUseCase.execute(recordId, request));
+        return ResponseService.getDataResponse(
+                createCommentUseCase.execute(recordId, request, getCurrentUserSocialId()));
     }
 
     @PutMapping("/{recordId}/comment/{commentId}")

--- a/Module-API/src/main/java/depromeet/api/domain/comment/usecase/CreateCommentUseCase.java
+++ b/Module-API/src/main/java/depromeet/api/domain/comment/usecase/CreateCommentUseCase.java
@@ -8,6 +8,10 @@ import depromeet.common.annotation.UseCase;
 import depromeet.domain.comment.adaptor.CommentAdaptor;
 import depromeet.domain.record.adaptor.RecordAdaptor;
 import depromeet.domain.record.domain.Record;
+import depromeet.domain.user.adaptor.UserAdaptor;
+import depromeet.domain.user.domain.User;
+import depromeet.domain.userchallenge.adaptor.UserChallengeAdaptor;
+import depromeet.domain.userchallenge.domain.UserChallenge;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,12 +21,20 @@ public class CreateCommentUseCase {
 
     private final CommentAdaptor commentAdaptor;
     private final RecordAdaptor recordAdaptor;
+    private final UserAdaptor userAdaptor;
+    private final UserChallengeAdaptor userChallengeAdaptor;
     private final CommentMapper commentMapper;
 
     @Transactional
-    public CreateCommentResponse execute(Long recordId, CreateCommentRequest request) {
+    public CreateCommentResponse execute(
+            Long recordId, CreateCommentRequest request, String socialId) {
+
+        User user = userAdaptor.findUser(socialId);
         Record record = recordAdaptor.findRecord(recordId);
+        UserChallenge userChallenge =
+                userChallengeAdaptor.findUserChallenge(record.getChallenge().getId(), user.getId());
+
         return commentMapper.toCreateCommentResponse(
-                commentAdaptor.addComment(record, request.getContent()));
+                commentAdaptor.addComment(record, request.getContent(), userChallenge));
     }
 }

--- a/Module-API/src/test/java/depromeet/api/domain/comment/controller/CommentControllerTest.java
+++ b/Module-API/src/test/java/depromeet/api/domain/comment/controller/CommentControllerTest.java
@@ -85,7 +85,7 @@ public class CommentControllerTest {
                         .commentDate(LocalDateTime.now())
                         .build();
 
-        when(createCommentUseCase.execute(anyLong(), any())).thenReturn(response);
+        when(createCommentUseCase.execute(anyLong(), any(), anyString())).thenReturn(response);
 
         mockMvc.perform(
                         post("/record/{recordId}/comment", 1L)
@@ -101,7 +101,7 @@ public class CommentControllerTest {
                         jsonPath("$.result.nickname").value(response.getNickname()),
                         jsonPath("$.result.content").value(response.getContent()));
 
-        verify(createCommentUseCase, times(1)).execute(anyLong(), any());
+        verify(createCommentUseCase, times(1)).execute(anyLong(), any(), anyString());
     }
 
     @Test

--- a/Module-Domain/src/main/java/depromeet/domain/comment/adaptor/CommentAdaptor.java
+++ b/Module-Domain/src/main/java/depromeet/domain/comment/adaptor/CommentAdaptor.java
@@ -6,6 +6,7 @@ import depromeet.domain.comment.domain.Comment;
 import depromeet.domain.comment.exception.CommentNotFoundException;
 import depromeet.domain.comment.repository.CommentRepository;
 import depromeet.domain.record.domain.Record;
+import depromeet.domain.userchallenge.domain.UserChallenge;
 import lombok.RequiredArgsConstructor;
 
 @Adaptor
@@ -14,8 +15,8 @@ public class CommentAdaptor {
 
     private final CommentRepository commentRepository;
 
-    public Comment addComment(Record record, String content) {
-        Comment comment = Comment.create(record.getUserChallenge(), record, content);
+    public Comment addComment(Record record, String content, UserChallenge userChallenge) {
+        Comment comment = Comment.create(userChallenge, record, content);
         return commentRepository.save(comment);
     }
 

--- a/Module-Domain/src/main/java/depromeet/domain/comment/domain/Comment.java
+++ b/Module-Domain/src/main/java/depromeet/domain/comment/domain/Comment.java
@@ -50,7 +50,7 @@ public class Comment extends BaseTime {
     }
 
     public void isCommenter(String socialId) {
-        if (!this.getRecord().getUser().getSocial().getId().equals(socialId))
+        if (!this.getUserChallenge().getUser().getSocial().getId().equals(socialId))
             throw CommentNotBelongToUserException.EXCEPTION;
     }
 


### PR DESCRIPTION
## 개요
- close #384 

## 작업사항
- 댓글 생성 시 댓글 작성자의 닉네임이 들어가도록 수정
- 댓글 삭제 시 유저 검증 로직 수정